### PR TITLE
Fixes: #9748, out of memory during record export

### DIFF
--- a/civicrm/custom/php/CRM/Contact/BAO/Query.php
+++ b/civicrm/custom/php/CRM/Contact/BAO/Query.php
@@ -44,6 +44,7 @@ class CRM_Contact_BAO_Query {
    * @var int
    */
   CONST
+    NO_RETURN_PROPERTIES = 'CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES',
     MODE_CONTACTS = 1,
     MODE_CONTRIBUTE = 2,
     MODE_MEMBER = 8,
@@ -426,7 +427,10 @@ class CRM_Contact_BAO_Query {
       $this->_params = array();
     }
 
-    if (empty($returnProperties)) {
+    if ($returnProperties === self::NO_RETURN_PROPERTIES) {
+      $this->_returnProperties = array();
+    }
+    elseif (empty($returnProperties)) {
       $this->_returnProperties = self::defaultReturnProperties($mode);
     }
     else {

--- a/civicrm/custom/php/CRM/Contact/BAO/Query.php
+++ b/civicrm/custom/php/CRM/Contact/BAO/Query.php
@@ -43,6 +43,10 @@ class CRM_Contact_BAO_Query {
    *
    * @var int
    */
+  /*
+   * NYSS #9748
+   * add NO_RETURN_PROPERTIES constant
+   */
   CONST
     NO_RETURN_PROPERTIES = 'CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES',
     MODE_CONTACTS = 1,
@@ -427,6 +431,10 @@ class CRM_Contact_BAO_Query {
       $this->_params = array();
     }
 
+    /*
+     * NYSS #9748
+     * add check for new constant to allow for *no* special fields in return
+     */
     if ($returnProperties === self::NO_RETURN_PROPERTIES) {
       $this->_returnProperties = array();
     }

--- a/civicrm/custom/php/CRM/Contact/Form/Task.php
+++ b/civicrm/custom/php/CRM/Contact/Form/Task.php
@@ -313,9 +313,6 @@ class CRM_Contact_Form_Task extends CRM_Core_Form {
       $queryOperator
     );
 
-    //NYSS 7715 bump memory temporarily
-    ini_set('memory_limit', '2G');
-
     $contactIds = array();
     while ($dao->fetch()) {
       $contactIds[$dao->contact_id] = $dao->contact_id;

--- a/civicrm/custom/php/CRM/Contact/Form/Task/ExportPrintProduction.php
+++ b/civicrm/custom/php/CRM/Contact/Form/Task/ExportPrintProduction.php
@@ -185,7 +185,6 @@ class CRM_Contact_Form_Task_ExportPrintProduction extends CRM_Contact_Form_Task
    */
   public function postProcess() {
     ini_set('max_execution_time', 1800);
-    ini_set('memory_limit', '2G');
 
     //set start time
     itime('start');
@@ -535,7 +534,14 @@ class CRM_Contact_Form_Task_ExportPrintProduction extends CRM_Contact_Form_Task
 
     //retrieve records from temp table
     $sql = "SELECT * FROM $tmpTbl";
-    $dao = CRM_Core_DAO::executeQuery($sql, CRM_Core_DAO::$_nullArray);
+    /**
+     * NYSS #9748
+     * force an unbuffered query
+     */
+    $dao = new CRM_Core_DAO();
+    $dao->setOptions( array('result_buffering'=>0) );
+    $sql = CRM_Core_DAO::composeQuery( $sql, CRM_Core_DAO::$_nullArray );
+    $dao->query($sql);
 
     //fetch records
     itime('before fetching records from temp table');

--- a/civicrm/custom/php/CRM/Contact/Selector.php
+++ b/civicrm/custom/php/CRM/Contact/Selector.php
@@ -1112,15 +1112,16 @@ SELECT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.dis
 
     if (!$displayRelationshipType) {
       $query = new CRM_Contact_BAO_Query($params,
-        $this->_returnProperties,
-        NULL, FALSE, FALSE, 1,
+        CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,
+        array('contact_id'), FALSE, FALSE, 1,
         FALSE, TRUE, TRUE, NULL,
         $queryOperator
       );
     }
     else {
-      $query = new CRM_Contact_BAO_Query($params, $this->_returnProperties,
-        NULL, FALSE, FALSE, 1,
+      $query = new CRM_Contact_BAO_Query($params, 
+        CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,
+        array('contact_id'), FALSE, FALSE, 1,
         FALSE, TRUE, TRUE, $displayRelationshipType,
         $queryOperator
       );

--- a/civicrm/custom/php/CRM/Contact/Selector.php
+++ b/civicrm/custom/php/CRM/Contact/Selector.php
@@ -1110,6 +1110,10 @@ SELECT 'civicrm_contact', contact_a.id, contact_a.id, '$cacheKey', contact_a.dis
       CRM_Contact_BAO_ProximityQuery::fixInputParams($params);
     }
 
+    /*
+     * NYSS #9748
+     * use new NO_RETURN_PROPERTIES constant to force minimal fields in return
+     */
     if (!$displayRelationshipType) {
       $query = new CRM_Contact_BAO_Query($params,
         CRM_Contact_BAO_Query::NO_RETURN_PROPERTIES,

--- a/modules/civicrm/CRM/Core/DAO.php
+++ b/modules/civicrm/CRM/Core/DAO.php
@@ -72,6 +72,12 @@ class CRM_Core_DAO extends DB_DataObject {
 
   static $_checkedSqlFunctionsExist = FALSE;
 
+  /*
+   * NYSS #9748
+   * internal variable for DAO to hold per-query settings
+   */
+  protected $_options = array();
+
   /**
    * Class constructor
    *
@@ -151,13 +157,25 @@ class CRM_Core_DAO extends DB_DataObject {
    * @return object              the current DAO object after the query execution
    */
   function query($query, $i18nRewrite = TRUE) {
+    /**
+     * NYSS #9748
+     * implementing per-query options at DAO level
+     */
     // rewrite queries that should use $dbLocale-based views for multi-language installs
-    global $dbLocale;
+    global $dbLocale, $_DB_DATAOBJECT;
+
+    $conn = &$_DB_DATAOBJECT['CONNECTIONS'][$this->_database_dsn_md5];
+    $orig_options = $conn->options;
+    $this->_setDBOptions($this->_options);
+
     if ($i18nRewrite and $dbLocale) {
       $query = CRM_Core_I18n_Schema::rewriteQuery($query);
     }
+    $ret = parent::query($query);
 
-    return parent::query($query);
+    $this->_setDBOptions($orig_options);
+
+    return $ret;
   }
 
   /**
@@ -1967,6 +1985,37 @@ EOS;
     // we'll append 8 characters to the end of the tableName
     $md5string = substr(md5($string), 0, 8);
     return substr($string, 0, $length - 8) . "_{$md5string}";
+  }
+
+  /**
+   * NYSS #9748
+   * Sets the internal options to be used on a query
+   *
+   * @param array $options
+   *
+   */
+  function setOptions($options) {
+    if (is_array($options)) {
+      $this->_options = $options;
+    }
+  }
+
+  /**
+   * NYSS #9748
+   * wrapper to pass internal DAO options down to DB_mysql/DB_Common level
+   *
+   * @param array $options
+   *
+   */
+  protected function _setDBOptions($options) {
+    global $_DB_DATAOBJECT;
+
+    if (is_array($options) && count($options)) {
+      $conn = &$_DB_DATAOBJECT['CONNECTIONS'][$this->_database_dsn_md5];
+      foreach ($options as $option_name => $option_value) {
+        $conn->setOption($option_name, $option_value);
+      }
+    }
   }
 
   function setApiFilter(&$params) {}


### PR DESCRIPTION
Exposes unbuffered query functionality to CRM_Core_DAO, allowing the export process to leverage the database server's resources during compilation.  Also fine-tunes the initial contact_id population query for the task object, removing all but the necessary fields from the SELECT.

These changes will also be submitted to core.
