### PR TITLE
Fix -- quote db fields

### DIFF
--- a/scripts/manageLdapConfig.php
+++ b/scripts/manageLdapConfig.php
@@ -143,7 +143,7 @@ function setFields($dbh, $tabname, $fields)
 
   $sql_set = $delim = '';
   foreach ($fields as $fldname => $fldval) {
-    $sql_set .= "$delim $fldname = '$fldval'";
+    $sql_set .= "$delim `$fldname` = '$fldval'";
     if (empty($delim)) {
       $delim = ',';
     }


### PR DESCRIPTION
Quoting field names in dynamically generated database query to avoid reserved word conflicts.