### PR TITLE
Prioritized Continue action over Copy action - issue #16659

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.mail/mail.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/mail.php
@@ -497,6 +497,11 @@ function mail_civicrm_links($op, $objectName, $objectId, &$links, &$mask, &$valu
       if ($link['name'] == 'Public View') {
         unset($links[$key]);
       }
+      // 16659 "Continue" should be prioritized over "Copy"
+      // for unscheduled mass emails
+      if ($op == 'view.mailing.browse.unscheduled' && $link['name'] == 'Continue') {
+        $links[$key]['weight'] = "-50";
+      }
     }
   }
 


### PR DESCRIPTION
See issue #15559. From Hayden, in a nutshell: Continue should appear with copy and deleted as additional options. I don't want users to see copy over continue for fear of them making changing/a copy rather than continuing their current mailing.