### PR TITLE
Ticket 16799 store survey data in Activity Details

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.webintegration/CRM/NYSS/WebIntegration/Upgrader.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/CRM/NYSS/WebIntegration/Upgrader.php
@@ -57,7 +57,7 @@ class CRM_NYSS_WebIntegration_Upgrader extends CRM_NYSS_WebIntegration_Upgrader_
     $this->ctx->log->info('Applying upgrade step 1001 in CRM_NYSS_WebIntegration_Upgrader');
     // NYSS #16799 New field to store survey field data as JSON
     $results = \Civi\Api4\CustomField::create(FALSE)
-      ->addValue('custom_group_id', 10)
+      ->addValue('custom_group_id.name', 'Website_Survey')
       ->addValue('name', 'survey_data')
       ->addValue('data_type', 'Memo')
       ->addValue('is_searchable', FALSE)

--- a/civicrm/custom/ext/gov.nysenate.webintegration/CRM/NYSS/WebIntegration/Upgrader.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/CRM/NYSS/WebIntegration/Upgrader.php
@@ -50,6 +50,32 @@ class CRM_NYSS_WebIntegration_Upgrader extends CRM_NYSS_WebIntegration_Upgrader_
   }
 
   /**
+   * Upgrade from version 1.0 to 1.1
+   *
+   */
+  public function upgrade_1001() {
+    $this->ctx->log->info('Applying upgrade step 1001 in CRM_NYSS_WebIntegration_Upgrader');
+    // NYSS #16799 New field to store survey field data as JSON
+    $results = \Civi\Api4\CustomField::create(FALSE)
+      ->addValue('custom_group_id', 10)
+      ->addValue('name', 'survey_data')
+      ->addValue('data_type', 'Memo')
+      ->addValue('is_searchable', FALSE)
+      ->addValue('is_required', FALSE)
+      ->addValue('label', 'Survey Data')
+      ->addValue('html_type', 'TextArea')
+      ->addValue('is_active', TRUE)
+      ->addValue('is_view', TRUE)
+      ->execute();
+
+    $this->ctx->log->debug($results);
+    if ($results->first()) {
+      return TRUE;
+    }
+  }
+
+
+  /**
    * Example: Run an external SQL script when the module is uninstalled.
    *
   public function uninstall() {

--- a/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Civi\Api4\Action\WebIntegration;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use PHPUnit\Exception;
+/**
+ * NYSS 16799
+ * cv api4 WebIntegration.migrateSurveyData
+ */
+class MigrateSurveyData extends AbstractAction {
+
+  /**
+   * When specified in the API call, will limit migration and results to
+   * this Activity Record.
+   */
+  protected $activity_id;
+
+
+  /**
+   * @inheritDoc
+   */
+  public function _run(Result $result) {
+    \Civi::log()->info('Running NYSS Migrate Survey Data', []);
+    
+    // Get all custom "Survey" groups
+    $customGroups = \Civi\Api4\CustomGroup::get($this->getCheckPermissions())
+      ->addSelect('*')
+      ->addWhere('title', 'REGEXP', '^Survey')
+      //->setLimit(25)
+      ->execute();
+
+    // For each survey, get the custom field values (survey submissions) and
+    // populate the appropriate Activity Details of the matching entity
+    foreach ($customGroups as $customGroup) {
+      \Civi::log()->info('Processing Custom Group: ' . $customGroup['title'], [
+        'name' => $customGroup['name'],
+        'id' => $customGroup['id'],
+        'title' => $customGroup['title'],
+        'table_name' => $customGroup['table_name']
+      ]);
+      /*\Civi::log()->debug('Processing Custom Group: ' . $customGroup['title'], [
+        'data' => $customGroup
+      ]);*/
+
+      // find all activities related to this custom group / survey
+      $webform_id = substr($customGroup['name'],7);
+      $webform_name = 'Survey_'.$webform_id;
+      $query = \Civi\Api4\Activity::get($this->getCheckPermissions())
+        ->addSelect($webform_name.'.*', 'Website_Survey.*', '*')
+        ->addWhere('activity_type_id', '=', 90)
+        ->addWhere('Website_Survey.Survey_ID', '=', $webform_id);
+      if ($this->activity_id) {
+        $query->addWhere('id', '=', $this->activity_id);
+      }
+        //->setLimit(25);
+      $activities = $query->execute();
+
+      //process each activity
+      foreach ($activities as $activity) {
+        \Civi::log()->info('Processing Activity: ' . $activity['id'], [
+          //'data' => $activity
+        ]);
+        // Format data
+        $fields_as_text = '';
+        $data_fields = [];
+        foreach(array_keys($activity) as $activity_key) {
+          if (preg_match('/^'.$webform_name.'\.(.+)$/', $activity_key,$matches)) {
+            $field_name = strtolower($matches[1]);
+            $data_fields[$field_name] = $activity[$activity_key];
+            $fields_as_text .= \CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent::formatFieldForText($field_name,$activity[$activity_key] ?? '');
+          }
+        }
+
+        try {
+          // Update Activity Details Field and Survey Data
+          $update_results = \Civi\Api4\Activity::update($this->getCheckPermissions())
+            ->addValue('details', '<pre>'.$fields_as_text.'</pre>')
+            ->addValue('Website_Survey.survey_data', json_encode($data_fields))
+            ->addWhere('id', '=', $activity['id'])
+            ->execute();
+
+          $update_results->single();
+          $result->append([
+            'activity_id' => $activity['id'],
+            'webform_id' => $webform_id,
+            'webform_name' => $webform_name,
+            'webform_data' => json_encode($data_fields)
+          ]);
+          \Civi::log()->info('Activity Updated: ' . $activity['id'], []);
+        } catch(Exception $e) {
+          \Civi::log()->info('Exception updating Activity ('.$activity['id'].') details.', [
+            'activity' => $activity,
+            'exception' => $e
+          ]);
+        }
+      }
+    }
+  }
+}

--- a/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
@@ -49,7 +49,7 @@ class MigrateSurveyData extends AbstractAction {
       $webform_name = 'Survey_'.$webform_id;
       $query = \Civi\Api4\Activity::get($this->getCheckPermissions())
         ->addSelect($webform_name.'.*', 'Website_Survey.*', '*')
-        ->addWhere('activity_type_id', '=', 90)
+        ->addWhere('activity_type_id:name', '=', 'Website Survey')
         ->addWhere('Website_Survey.Survey_ID', '=', $webform_id);
       if ($this->activity_id) {
         $query->addWhere('id', '=', $this->activity_id);

--- a/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
@@ -24,6 +24,25 @@ class MigrateSurveyData extends AbstractAction {
   public function _run(Result $result) {
     \Civi::log()->info('Running NYSS Migrate Survey Data', []);
 
+    // Verify that Website_Survey.survey_data field exists
+    $data_field = \Civi\Api4\CustomField::get($this->getCheckPermissions())
+      ->addWhere('custom_group_id:name', '=', 'Website_Survey')
+      ->addWhere('name', '=', 'survey_data')
+      ->setLimit(25)
+      ->execute();
+
+    if ($data_field->count() != 1) {
+      // Throwing Exception because it forces an error in calling shell
+      // command ($?)
+      throw new \CRM_Core_Exception('Missing required Website_Survey.survey_data field.');
+      /*
+      return [
+        'is_error' => 1,
+        'error_message' => 'Missing required Website_Survey.survey_data field.',
+      ];
+      */
+    }
+
     // Get all custom "Survey" groups
     $customGroups = \Civi\Api4\CustomGroup::get($this->getCheckPermissions())
       ->addSelect('*')

--- a/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/MigrateSurveyData.php
@@ -23,7 +23,7 @@ class MigrateSurveyData extends AbstractAction {
    */
   public function _run(Result $result) {
     \Civi::log()->info('Running NYSS Migrate Survey Data', []);
-    
+
     // Get all custom "Survey" groups
     $customGroups = \Civi\Api4\CustomGroup::get($this->getCheckPermissions())
       ->addSelect('*')
@@ -68,11 +68,11 @@ class MigrateSurveyData extends AbstractAction {
         foreach(array_keys($activity) as $activity_key) {
           if (preg_match('/^'.$webform_name.'\.(.+)$/', $activity_key,$matches)) {
             $field_name = strtolower($matches[1]);
-            $data_fields[$field_name] = $activity[$activity_key];
+            // this format will mimic format used for future accumulator data.
+            $data_fields[] = (object)['field'=>$field_name, 'value'=>$activity[$activity_key]];
             $fields_as_text .= \CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent::formatFieldForText($field_name,$activity[$activity_key] ?? '');
           }
         }
-
         try {
           // Update Activity Details Field and Survey Data
           $update_results = \Civi\Api4\Activity::update($this->getCheckPermissions())

--- a/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/UpdateSurveyGroups.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/Action/WebIntegration/UpdateSurveyGroups.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Civi\Api4\Action\WebIntegration;
+
+use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
+use PHPUnit\Exception;
+
+class UpdateSurveyGroups extends AbstractAction {
+
+  /**
+   * Set is_active to this value
+   * @var bool|null
+   */
+  protected ?bool $active = null;
+
+  /**
+   * Set is_public to this value
+   * @var bool|null
+   */
+  protected ?bool $public = null;
+
+  /**
+   * @inheritDoc
+   */
+  public function _run(Result $result) {
+    \Civi::log()->info('Running NYSS Update Survey Groups', [
+      'active' => $this->active,
+      'public' => $this->public
+    ]);
+
+    // Get all custom "Survey" groups
+    $customGroups = \Civi\Api4\CustomGroup::get($this->getCheckPermissions())
+      ->addSelect('*')
+      ->addWhere('title', 'REGEXP', '^Survey')
+      ->addWhere('is_active', '!=', $this->active)
+      ->addWhere('is_public', '!=', $this->public)
+      //->setLimit(25)
+      ->execute();
+
+    // For each survey, get the custom field values (survey submissions) and
+    // populate the appropriate Activity Details of the matching entity
+    foreach ($customGroups as $customGroup) {
+      \Civi::log()->info('Updating Custom Group: ' . $customGroup['title'], [
+        'name' => $customGroup['name'],
+        'id' => $customGroup['id'],
+        'title' => $customGroup['title'],
+        'table_name' => $customGroup['table_name'],
+        'is_active' => $customGroup['is_active'],
+        'is_public' => $customGroup['is_public']
+      ]);
+
+      try {
+        // Update Custom Group, setting is_active and is_public only
+        $update_results = \Civi\Api4\CustomGroup::update($this->getCheckPermissions())
+          ->addValue('is_active', $this->active)
+          ->addValue('is_public', $this->public)
+          ->addWhere('id', '=', $customGroup['id'])
+          ->execute();
+
+        $result->append([
+          $update_results->single()
+        ]);
+        \Civi::log()->info('Custom Group Updated: ' . $customGroup['id'], []);
+      } catch(Exception $e) {
+        \Civi::log()->info('Exception updating Custom Group ('.$customGroup['id'].') details.', [
+          'custom_group' => $customGroup,
+          'exception' => $e
+        ]);
+      }
+    }
+  }
+
+}

--- a/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/WebIntegration.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/Civi/Api4/WebIntegration.php
@@ -1,0 +1,17 @@
+<?php
+namespace Civi\Api4;
+
+class WebIntegration extends Generic\AbstractEntity {
+  public static function getFields($checkPermissions = TRUE) {
+    return (new Generic\BasicGetFieldsAction(__CLASS__, __FUNCTION__, function($getFieldsAction) {
+      return [
+       /* [
+          'name' => 'activity_id',
+          'data_type' => 'Integer',
+          'description' => 'Activity ID. Will limit migration to the specified Activity.',
+        ],
+      */
+      ];
+    }))->setCheckPermissions($checkPermissions);
+  }
+}

--- a/civicrm/custom/ext/gov.nysenate.webintegration/info.xml
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2017-02-20</releaseDate>
-  <version>1.0</version>
+  <version>1.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.7</ver>

--- a/civicrm/custom/ext/gov.nysenate.webintegration/info.xml
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/info.xml
@@ -12,7 +12,7 @@
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2021-12-06</releaseDate>
-  <version>1.2</version>
+  <version>1.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.75</ver>

--- a/civicrm/custom/ext/gov.nysenate.webintegration/info.xml
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/info.xml
@@ -11,14 +11,17 @@
   <urls>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2017-02-20</releaseDate>
-  <version>1.1</version>
+  <releaseDate>2021-12-06</releaseDate>
+  <version>1.2</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>5.75</ver>
   </compatibility>
   <comments/>
   <civix>
     <namespace>CRM/NYSS/WebIntegration</namespace>
   </civix>
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi" />
+  </classloader>
 </extension>

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/Website.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/Website.php
@@ -763,8 +763,9 @@ class CRM_NYSS_BAO_Integration_Website
   } // processCommunication()
 
 
-  /*
+  /**
    * handle surveys (questionnaire response) with
+   * @deprecated See CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent
    */
   static function processSurvey($contactId, $action, $params)
   {
@@ -899,9 +900,10 @@ class CRM_NYSS_BAO_Integration_Website
   } // getMessages()
 
 
-  /*
+  /**
    * check if survey already exists; if so, return fields by label
    * else return false
+   * @deprecated See CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent
    */
   static function surveyExists($params)
   {
@@ -951,8 +953,9 @@ class CRM_NYSS_BAO_Integration_Website
   } //surveyExists()
 
 
-  /*
+  /**
    * create custom data set and fields for survey
+   * @deprecated See CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent
    */
   static function buildSurvey($data) {
     if (empty($data->form_id)) {
@@ -1075,6 +1078,7 @@ class CRM_NYSS_BAO_Integration_Website
     return $fields;
   } //buildSurvey()
 
+  /** @deprecated See CRM_NYSS_BAO_Integration_WebsiteEvent_BillEvent */
   static function buildBillName($params) {
     //get data pieces from possible locations
     $bill_number = (!empty($params->event_info->bill_number)) ?

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent.php
@@ -271,6 +271,10 @@ abstract class CRM_NYSS_BAO_Integration_WebsiteEvent implements CRM_NYSS_BAO_Int
     return $this->event_data->getEventInfo();
   }
 
+  public function getEventInfoJson(): string {
+    return json_encode($this->event_data->getEventInfo());
+  }
+
   public function getEventAction(): string {
     return $this->event_data->getEventAction();
   }

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
@@ -227,7 +227,11 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
    * @return string
    */
   public static function formatFieldForText(string $label,string $value) {
-    return ucwords(strtr($label,'_',' ')) . ': ' . self::cleanFieldValue($value) . "\n";
+    // preg_replace removes trailing : and whitespace
+    // strtr replaces _ with space
+    // ucwords will tranform each word to have a capital first letter
+    $clean_label = ucwords(preg_replace('/[\s:]*$/', '',strtr($label,['_'=>' '])));
+    return $clean_label . ': ' . self::cleanFieldValue($value ?? '') . "\n";
   }
 
   /**

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
@@ -58,7 +58,6 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
     // $result = CRM_NYSS_BAO_Integration_Website::processSurvey($contact_id, $this->getEventAction(), $params);
 
     // create activity
-    $activity_type_id = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Website Survey');
     $event_info = $this->getEventInfo();
     $form_fields = $event_info->form_values;
     $fields_as_text = array_reduce($form_fields, function ($carry, $field) {
@@ -66,7 +65,7 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
     });
 
     $results = \Civi\Api4\Activity::create($this->getCiviPermissionCheck())
-      ->addValue('activity_type_id', $activity_type_id)
+      ->addValue('activity_type_id:name', 'Website Survey')
       ->addValue('target_contact_id', $contact_id)
       ->addValue('activity_date_time', $this->getEventData()->getCreatedAtAsDateTime()->format('Y-m-d H:i:s'))
       ->addValue('details', '<pre>'.$fields_as_text.'</pre>')

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
@@ -52,33 +52,24 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
    * @throws \Civi\API\Exception\UnauthorizedException
    */
   protected function processForm(int $contact_id): void {
-    // form_id, form_values, form_title, detail??
-    //$params = new stdClass();
-    //$params->form_id = $this->getFormId();
-    //$params->form_values = $this->getFormFields();
-    //$params->form_title = $this->getFormTitle();
-    //$params->detail = $this->getEventDetails();
-    //$params->created_at = $this->getEventData()->getCreatedAtAsDateTime();
 
-    // used to lean on CRM_NYSS_BAO_Integration_Website::processSurvey()
-    //$result = CRM_NYSS_BAO_Integration_Website::processSurvey($contact_id, $this->getEventAction(), $params);
-    //if ($result['is_error'] == 1) {
-      //throw new Exception("Error processing webform/survey: " . $result['error_message']);
-    //}
+    // NYSS 16799 -- No more custom field groups for surveys. Now, we just add
+    // to Activity.details and Website_Survey.survey_data
+    // $result = CRM_NYSS_BAO_Integration_Website::processSurvey($contact_id, $this->getEventAction(), $params);
 
     // create activity
     $activity_type_id = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Website Survey');
-    $form_fields = $this->getFormFields();
-    $fields_as_text = array_reduce($form_fields, function($carry, $item) {
-      return $carry . '<div class="survey-field survey-field--'.$item->field.'">' . ucwords(strtr($item->field,'_',' ')) . ': ' . $item->value . "</div>\n";
+    $event_info = $this->getEventInfo();
+    $form_fields = $event_info->form_values;
+    $fields_as_text = array_reduce($form_fields, function ($carry, $field) {
+      return $carry . self::formatFieldsAsText($field->field, $field->value);
     });
 
-    print_r($this->getEventInfo());
     $results = \Civi\Api4\Activity::create($this->getCiviPermissionCheck())
       ->addValue('activity_type_id', $activity_type_id)
       ->addValue('target_contact_id', $contact_id)
       ->addValue('activity_date_time', $this->getEventData()->getCreatedAtAsDateTime()->format('Y-m-d H:i:s'))
-      ->addValue('details', $fields_as_text)
+      ->addValue('details', '<pre>'.$fields_as_text.'</pre>')
       ->addValue('subject', $this->getFormTitle())
       // based on logic from CRM_NYSS_BAO_Integration_Website::processSurvey()
       ->addValue('source_contact_id', civicrm_api3('uf_match', 'getvalue', [
@@ -88,8 +79,7 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
       // create custom data
       ->addValue('Website_Survey.Survey_Name', $this->getFormTitle())
       ->addValue('Website_Survey.Survey_ID', $this->getFormId())
-      ->addValue('Website_Survey.survey_data', $this->getEventInfoJson())
-      //->addValue(Website_Survey.)
+      ->addValue('Website_Survey.survey_data', json_encode($form_fields))
       ->execute();
 
     // verification check only. Throws Exception if there's not 1 result
@@ -116,6 +106,7 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
    * CRM_NYSS_BAO_Integration_Website::processSurvey() and with CiviCRM's
    * custom_field structure.
    * @return array of objects (field name, field value)
+   * @deprecated
    */
   public function getFormFields() : array {
     $event_info = $this->getEventInfo();
@@ -134,6 +125,10 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
    * field names/labels and adds each field to $field for the sake of
    * flattening a bigger data structure to accommodate
    * CRM_NYSS_BAO_Integration_Website::processSurvey()
+   * @deprecated This was previously used to flatten a multi-level data structure
+   * into a flat structure for the sake of saving to fields in a single database table.
+   * No longer necessary since data is now being saved as text
+   * @note formatFieldsAsText() is kind-of the replacement for this.
    */
   protected function inspectField(mixed $value, array &$fields, string $key = '', string $start_label = '') : void {
     // $used_labels tracks used labels to facilitate label uniqueness
@@ -168,6 +163,7 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
    * Takes the given string ($str) and makes sure that it is unique among
    * ($existing) strings. If not unique, appends a number to make it unique.
    * @return string
+   * @deprecated Was previously needed for Civi Custom Fields.
    */
   public static function ensureUnique(string $str, array $existing, int $max_length = 1020) : string {
     $cnt = 1;
@@ -182,27 +178,81 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
   }
 
   /**
+   * Turns a Survey field data structure into reasonably readable text that
+   * can be added to the Activity details field. It will return a simple
+   * label / value pair as:
+   * Label: Value
+   * or it recurses into a more complex data structure to come up with something
+   * reasonable.
+   * Address:
+   *   Address 1: 1 Main St
+   *   Address 2: Suite 12
+   *   City: Albany
+   *   etc...
+   * @param string $label The field label
+   * @param mixed $value The field value, which could contain a deeper structure
+   * @param int $level The current level in the structure. Mostly for indentation purposes.
+   * @param string $carry_text Allows recursive calls to add to the resulting string.
+   *
+   * @return string
+   */
+  public static function formatFieldsAsText(string $label, mixed $value, int $level = 0, string &$carry_text = '') : string {
+    if (is_scalar($value) or is_null($value)) {
+      // It's a "simple value" field. Just add the field
+      $carry_text .= str_repeat('  ', $level) . self::formatFieldForText($label, $value);
+      return $carry_text; // don't recurse
+    } else if (is_array($value)) {
+      if (array_reduce($value, fn($c, $v) => $c && (is_scalar($v) || is_null($v)),
+        TRUE)) {
+        // It's an array of "simple values"... join them into a single field
+        $carry_text .= str_repeat('  ', $level) .  self::formatFieldForText($label, join(', ', (array) $value));
+        return $carry_text; // don't recurse
+      }
+    }
+    // Complex values require some recursion to break them into additional fields.
+    if (is_array($value) or is_object($value)) {
+      $carry_text .= str_repeat('  ', $level) . self::formatFieldForText($label,'');
+      ++$level;
+      foreach($value as $child_key => $child_value) {
+        self::formatFieldsAsText($child_key, $child_value, $level, $carry_text);
+      }
+    }
+    return $carry_text;
+  }
+
+  /**
+   * For consistent formating of webform/survey fields to be added to Activity.details.
    * @param string $label
    * @param string $value
+   * @return string
+   */
+  public static function formatFieldForText(string $label,string $value) {
+    return ucwords(strtr($label,'_',' ')) . ': ' . self::cleanFieldValue($value) . "\n";
+  }
+
+  /**
    * Create a field in the proper format for
    * CRM_NYSS_BAO_Integration_Website::processSurvey()
+   * @param string $label
+   * @param string $value
    * @return object
+   * @deprecated No longer using processSurvey()
    */
   protected function getFieldDef(string $label, string $value) : object {
     return (object) [
       "field" => $label,
-      "value" => $this->cleanValue($value)
+      "value" => $this->cleanFieldValue($value)
     ];
   }
 
-  protected function cleanValue(string $string): string {
+  protected static function cleanFieldValue(string $string): string {
     // keep newlines
     $string = str_replace(array("<p>", "</p>", "<br>", "<br/>"), "\n", $string);
     // remove HTML (probably unnecessary, but also, civicrm will convert to character
     // entities, which makes the string longer than expected e.g. "<" becomes
     // &lt; (4 characters)
     $string = strip_tags($string);
-    return substr($string, 0, 255);
+    return $string;
   }
 
   function getParentTagName(): string {

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
@@ -44,19 +44,56 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
     return $this;
   }
 
+  /**
+   * @param int $contact_id
+   *
+   * @return void
+   * @throws \CRM_Core_Exception
+   * @throws \Civi\API\Exception\UnauthorizedException
+   */
   protected function processForm(int $contact_id): void {
     // form_id, form_values, form_title, detail??
-    $params = new stdClass();
-    $params->form_id = $this->getFormId();
-    $params->form_values = $this->getFormFields();
-    $params->form_title = $this->getFormTitle();
-    $params->detail = $this->getEventDetails();
-    $params->created_at = $this->getEventData()->getCreatedAtAsDateTime();
+    //$params = new stdClass();
+    //$params->form_id = $this->getFormId();
+    //$params->form_values = $this->getFormFields();
+    //$params->form_title = $this->getFormTitle();
+    //$params->detail = $this->getEventDetails();
+    //$params->created_at = $this->getEventData()->getCreatedAtAsDateTime();
 
-    $result = CRM_NYSS_BAO_Integration_Website::processSurvey($contact_id, $this->getEventAction(), $params);
-    if ($result['is_error'] == 1) {
-      throw new Exception("Error processing webform/survey: " . $result['error_message']);
-    }
+    // used to lean on CRM_NYSS_BAO_Integration_Website::processSurvey()
+    //$result = CRM_NYSS_BAO_Integration_Website::processSurvey($contact_id, $this->getEventAction(), $params);
+    //if ($result['is_error'] == 1) {
+      //throw new Exception("Error processing webform/survey: " . $result['error_message']);
+    //}
+
+    // create activity
+    $activity_type_id = CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Website Survey');
+    $form_fields = $this->getFormFields();
+    $fields_as_text = array_reduce($form_fields, function($carry, $item) {
+      return $carry . '<div class="survey-field survey-field--'.$item->field.'">' . ucwords(strtr($item->field,'_',' ')) . ': ' . $item->value . "</div>\n";
+    });
+
+    print_r($this->getEventInfo());
+    $results = \Civi\Api4\Activity::create($this->getCiviPermissionCheck())
+      ->addValue('activity_type_id', $activity_type_id)
+      ->addValue('target_contact_id', $contact_id)
+      ->addValue('activity_date_time', $this->getEventData()->getCreatedAtAsDateTime()->format('Y-m-d H:i:s'))
+      ->addValue('details', $fields_as_text)
+      ->addValue('subject', $this->getFormTitle())
+      // based on logic from CRM_NYSS_BAO_Integration_Website::processSurvey()
+      ->addValue('source_contact_id', civicrm_api3('uf_match', 'getvalue', [
+        'uf_id' => 1,
+        'return' => 'contact_id',
+      ]))
+      // create custom data
+      ->addValue('Website_Survey.Survey_Name', $this->getFormTitle())
+      ->addValue('Website_Survey.Survey_ID', $this->getFormId())
+      ->addValue('Website_Survey.survey_data', $this->getEventInfoJson())
+      //->addValue(Website_Survey.)
+      ->execute();
+
+    // verification check only. Throws Exception if there's not 1 result
+    $results->single();
   }
 
   public function getFormId(): ?string {

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/WebsiteEvent/SurveyEvent.php
@@ -199,7 +199,7 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
   public static function formatFieldsAsText(string $label, mixed $value, int $level = 0, string &$carry_text = '') : string {
     if (is_scalar($value) or is_null($value)) {
       // It's a "simple value" field. Just add the field
-      $carry_text .= str_repeat('  ', $level) . self::formatFieldForText($label, $value);
+      $carry_text .= str_repeat('  ', $level) . self::formatFieldForText($label, $value ?? '');
       return $carry_text; // don't recurse
     } else if (is_array($value)) {
       if (array_reduce($value, fn($c, $v) => $c && (is_scalar($v) || is_null($v)),
@@ -245,7 +245,7 @@ class CRM_NYSS_BAO_Integration_WebsiteEvent_SurveyEvent extends CRM_NYSS_BAO_Int
   protected function getFieldDef(string $label, string $value) : object {
     return (object) [
       "field" => $label,
-      "value" => $this->cleanFieldValue($value)
+      "value" => $this->cleanFieldValue($value ?? '')
     ];
   }
 

--- a/scripts/migrateSurveyData.sh
+++ b/scripts/migrateSurveyData.sh
@@ -32,6 +32,10 @@ instance="$1"
 echo "migrating custom survey fields to Activity details field..."
 $drush $instance cvapi WebIntegration.migrateSurveyData version=4 checkPermissions=0
 
+MIGRATION_STATUS=$?
+
 # Deactivate Custom Survey Groups
-echo "deactivating survey custom data groups..."
-$drush $instance cvapi WebIntegration.updateSurveyGroups version=4 checkPermissions=0 active=0 public=0
+if [ $MIGRATION_STATUS = 0 ]; then
+  echo "deactivating survey custom data groups..."
+  $drush $instance cvapi WebIntegration.updateSurveyGroups version=4 checkPermissions=0 active=0 public=0
+fi

--- a/scripts/migrateSurveyData.sh
+++ b/scripts/migrateSurveyData.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+#
+# v37.sh
+#
+# Project: BluebirdCRM
+# Authors: Nathan Frank
+# Organization: New York State Senate
+# Date: 2024-12-04
+#
+# The purpose of this script is to execute a 1 time migration of custom activity data that is associated with
+# Website Surveys (Questionnaires) per ticket NYSS 16799. The script does the following:
+# 1. It takes all custom group and custom field survey data associated with Activities, formats the data as text and
+#    places the data in the Activity.details field.
+# 2. It also formats the data as JSON and puts it into the Website_Survey.survey_data field
+# 3. It deactivates all custom data groups associated with Surveys
+#
+# There's no harm in running this script more than once on a database instance. But, there should be no need to.
+# This is a "use it once and forget it" script.
+#
+
+prog=`basename $0`
+script_dir=`dirname $0`
+drush=$script_dir/drush.sh
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $prog instanceName" >&2
+  exit 1
+fi
+instance="$1"
+
+# Migrate Data
+echo "migrating custom survey fields to Activity details field..."
+$drush $instance cvapi WebIntegration.migrateSurveyData version=4 checkPermissions=0
+
+# Deactivate Custom Survey Groups
+echo "deactivating survey custom data groups..."
+$drush $instance cvapi WebIntegration.updateSurveyGroups version=4 checkPermissions=0 active=0 public=0


### PR DESCRIPTION
This PR includes changes that will:
1) store future survey field data as text in the Activity.details field
2) store future survey field data as JSON data in Website_Survey.survey_data
3) creates the Website_survey.survey_data field for the sake of #2
4) provide a migration script to (a) copy old survey data to Activity.details and (b) deactivate survey custom groups.