### PR TITLE
change "name" field to "label" - fixes #16826

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.tags/tags.php
+++ b/civicrm/custom/ext/gov.nysenate.tags/tags.php
@@ -388,7 +388,7 @@ function tags_civicrm_validateForm($formName, &$fields, &$files, &$form, &$error
     }
 
     //construct SQL clauses/params
-    $sqlParams = [1 => [$fields['name'], 'String']];
+    $sqlParams = [1 => [$fields['label'], 'String']];
     if (!empty($fields['parent_id'])) {
       $parentSql = "AND parent_id = %2";
       $sqlParams[2] = [$fields['parent_id'], 'Positive'];
@@ -406,7 +406,7 @@ function tags_civicrm_validateForm($formName, &$fields, &$files, &$form, &$error
     ", $sqlParams);
 
     if ($checkExistence) {
-      $errors['name'] = 'Tag names must be unique for a common parent tag.';
+      $errors['label'] = 'Tag names must be unique for a common parent tag.';
     }
   }
 } //tags_civicrm_validateForm()


### PR DESCRIPTION
This fixes #16826. It seems that a field that was previously referred to as "name" is now being referred to as "label". I changed our custom validation routine to accommodate that change.