### PR TITLE
remove auto-pausing mail jobs. fixes #16857

### DIFF
--- a/modules/civicrm/ext/flexmailer/src/Listener/DefaultSender.php
+++ b/modules/civicrm/ext/flexmailer/src/Listener/DefaultSender.php
@@ -77,13 +77,6 @@ class DefaultSender extends AutoService {
           $code = $result->getCode();
           \CRM_Core_Error::debug_log_message("SMTP Socket Error or failed to set sender error. Message: $message, Code: $code");
 
-          //NYSS
-          \CRM_Mailing_BAO_MailingJob::pause($mailing->id);
-          $msg = "A bulk mailing was paused (ID: {$mailing->id}) due to SMTP socket errors, suggesting a problem connecting with the SMTP provider.";
-          \CRM_NYSS_Errorhandler_BAO::notifySlack($msg, "Mailing {$mailing->id} Paused");
-          //NYSS 16512
-          \CRM_NYSS_BAO_Mailing::notify($mailing->id);
-
           // these are socket write errors which most likely means smtp connection errors
           // lets skip them and reconnect.
           $smtpConnectionErrors++;
@@ -92,6 +85,10 @@ class DefaultSender extends AutoService {
             $retryBatch = TRUE;
             continue;
           }
+
+          //NYSS
+          $msg = "A bulk mailing was deferred (ID: {$mailing->id}) due to excessive (more than 5) SMTP socket errors. This mailing will be retried.";
+          \CRM_NYSS_Errorhandler_BAO::notifySlack($msg, "Mailing Deferred {ID: $mailing->id}");
 
           // seems like we have too many of them in a row, we should
           // write stuff to disk and abort the cron job


### PR DESCRIPTION
@lcdservices I took a slightly different approach then I talked about earlier this week.
I looked in the logs, and I found that all errors were "Failed to set sender" errors -- most of which were triggered by a Sendgrid 421, which means "too many connections". Once I learned that, I decided not to complicate things right off the bat with customizing recordBounce(). I just removed the pausing, but kept the slack notification. I just moved it down below the 5 tries. If we were to start having problems with other types of error messages, then I can add more logic.