### PR TITLE
scripts - Improve Debian/Ubuntu compatibility. Use explicit shell.

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # backup.sh - Back up Bluebird code and data to a local or non-local directory.
 #

--- a/scripts/bluebird_setup.sh
+++ b/scripts/bluebird_setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # bluebird_setup.sh - Initialize ("spin up") a Bluebird CRM instance.
 #

--- a/scripts/changeCollation.sh
+++ b/scripts/changeCollation.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # changeCollation.sh
 #

--- a/scripts/changelog_v2/install.sh
+++ b/scripts/changelog_v2/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # install.sh - Install the new changelog summary/detail layer.
 #

--- a/scripts/cleanup_csv.sh
+++ b/scripts/cleanup_csv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # cleanup_csv.sh - Convert non-printable characters to printable equivalents,
 #                  and eliminate all pipes, backslashes, and tildes.

--- a/scripts/clearCache.sh
+++ b/scripts/clearCache.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # clearCache.sh
 #
@@ -184,7 +184,7 @@ data_owner=`$readConfig --ig $instance data.rootdir.owner | cut -d: -f1` || data
 
 if [ $EUID -eq 0 -a $skip_root_check -ne 1 ]; then
   echo "$prog: Running as root causes file permission problems; restarting as user apache"
-  exec su $data_owner -s /bin/sh -c "$0 $*"
+  exec su $data_owner -s /bin/bash -c "$0 $*"
 fi
 
 

--- a/scripts/convertLogInnoDB.sh
+++ b/scripts/convertLogInnoDB.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # convertLogInnoDB.sh - Convert logging tables to compressed InnoDB.
 #

--- a/scripts/convertUtf8mb4.sh
+++ b/scripts/convertUtf8mb4.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # convertUtf8mb4.sh
 #

--- a/scripts/convert_nonprintables.sh
+++ b/scripts/convert_nonprintables.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # convert_nonprintables.sh - Convert all non-printable characters to
 #                            printable equivalents.

--- a/scripts/copyArchive.sh
+++ b/scripts/copyArchive.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # copyArchive.sh - Copy an instance archive file (zip file containing two
 #                  SQL dump files) to a new file, prevserving proper naming.

--- a/scripts/copyInstance.sh
+++ b/scripts/copyInstance.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # copyInstance.sh - Copy one CRM database instance into another.
 #

--- a/scripts/countDupEmails.sh
+++ b/scripts/countDupEmails.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # countDupEmails.sh - Provides statistics on number of duplicate e-mails in CRM.
 #

--- a/scripts/countIssueNotes.sh
+++ b/scripts/countIssueNotes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # countIssueNotes.sh - Count number of "OMIS ISSUE CODES" notes in CRM.
 #

--- a/scripts/cv.sh
+++ b/scripts/cv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # cv.sh - A Bluebird-aware wrapper around the CiviCRM "cv" utility.
 #

--- a/scripts/dedupeSetup.sh
+++ b/scripts/dedupeSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # dedupeSetup.sh - All-in-one dedupe setup script.
 #

--- a/scripts/defaults.sh
+++ b/scripts/defaults.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # defaults.sh - Shell defaults when using the Bluebird config file.
 #

--- a/scripts/deleteBackups.sh
+++ b/scripts/deleteBackups.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # deleteBackups.sh - Delete instance backup files (data dumps)
 #

--- a/scripts/deleteEmptyEmailPhone.sh
+++ b/scripts/deleteEmptyEmailPhone.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # deleteEmptyEmailPhone.sh
 #

--- a/scripts/deleteEntityFileDupes.sh
+++ b/scripts/deleteEntityFileDupes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # deleteEntityFileDupes.sh
 #

--- a/scripts/deleteExports.sh
+++ b/scripts/deleteExports.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # deleteExports.sh - Delete print production export files
 #

--- a/scripts/deleteInstance.sh
+++ b/scripts/deleteInstance.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # deleteInstance.sh - Delete the databases and files for a CRM instance
 #

--- a/scripts/deleteOrphanedTags.sh
+++ b/scripts/deleteOrphanedTags.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # deleteOrphanedTags.sh - Delete Bluebird tags that are not associated with
 #                         any entities (contacts, cases, or activities),

--- a/scripts/dropCiviTriggers.sh
+++ b/scripts/dropCiviTriggers.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # dropCiviTriggers.sh
 #

--- a/scripts/drush.sh
+++ b/scripts/drush.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # drush.sh - A Bluebird-aware wrapper around the "drush" utility.
 #

--- a/scripts/filesToUpper.sh
+++ b/scripts/filesToUpper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # uppercase any filenames with lowercase chars
 for file in $*
  do

--- a/scripts/fixDupAddr.sh
+++ b/scripts/fixDupAddr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixDupAddr.sh - Nullify supp1 or supp2 values if they duplicate street_address
 #

--- a/scripts/fixDupePrimary.sh
+++ b/scripts/fixDupePrimary.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixDupePrimary.sh
 # 

--- a/scripts/fixEntityTags.sh
+++ b/scripts/fixEntityTags.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixEntityTags.sh - Analyze the civicrm_entity_tag table and fix problems.
 #

--- a/scripts/fixOmisStreetNum.sh
+++ b/scripts/fixOmisStreetNum.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixOmisStreetNum.sh - Use OMIS saved data to split HOUSE field into
 #                       street_number and street_number_suffix

--- a/scripts/fixPermissions.sh
+++ b/scripts/fixPermissions.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixPermissions.sh - Set Bluebird directory permissions appropriately.
 #

--- a/scripts/fixPhoneTypes.sh
+++ b/scripts/fixPhoneTypes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixPhoneTypes.sh - correct phone types assigned during OMIS import
 #

--- a/scripts/fixPrefixes.sh
+++ b/scripts/fixPrefixes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixPrefixes.sh - For records without a prefix, set prefix according to gender.
 #

--- a/scripts/fixPvtAddr.sh
+++ b/scripts/fixPvtAddr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixPvtAddr.sh - Remove "Pvt" from street_name and street_unit fields.
 #

--- a/scripts/fixRecordTypes.sh
+++ b/scripts/fixRecordTypes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixRecordTypes.sh - Set the record_type based on saved OMIS data
 #

--- a/scripts/fixSpaces.sh
+++ b/scripts/fixSpaces.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixSpaces.sh - Remove extraneous spaces from various databases fields.
 #

--- a/scripts/fixSuppAddr1.sh
+++ b/scripts/fixSuppAddr1.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixSuppAddr1.sh - Set supplemental_address_1 to NULL wherever possible.
 #

--- a/scripts/fixSuppAddr2.sh
+++ b/scripts/fixSuppAddr2.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # fixSuppAddr2.sh - Move e-mail addresses and/or phone numbers from
 #                   supplemental_address_2 into e-mail/phone tables.

--- a/scripts/flagBadEmails.sh
+++ b/scripts/flagBadEmails.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # flagBadEmails.sh - Analyze email addresses for validity
 #

--- a/scripts/hitInstance.sh
+++ b/scripts/hitInstance.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # hitInstance.sh
 #

--- a/scripts/iterateInstances.sh
+++ b/scripts/iterateInstances.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # iterateInstances.sh - Perform a command for one or more CRM instances
 #
@@ -191,7 +191,7 @@ for instance in $instances; do
     [ $quiet_mode -eq 0 ] && logdt "[$run_as@$instance] About to exec: $realcmd $bg_jobs" >&2
     [ $show_timing -eq 1 ] && echo "==> START [`date +%H:%M:%S.%N`]"
     if [ "$run_as" ]; then
-      su $run_as -s /bin/sh -c "$realcmd $bg_jobs"
+      su $run_as -s /bin/bash -c "$realcmd $bg_jobs"
     else
       eval $realcmd $bg_jobs
     fi

--- a/scripts/manageAccumulator.sh
+++ b/scripts/manageAccumulator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # manageAccumulator.sh - Perform operations on the Sendgrid Stats Accumulator
 #

--- a/scripts/manageCiviConfig.sh
+++ b/scripts/manageCiviConfig.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # manageCiviConfig.sh - Wrapper around manageCiviConfig.php
 #

--- a/scripts/manageLdapConfig.sh
+++ b/scripts/manageLdapConfig.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # manageLdapConfig.sh - Wrapper around manageLdapConfig.php
 #

--- a/scripts/manageSolrConfig.sh
+++ b/scripts/manageSolrConfig.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # manageSolrConfig.sh - Handle setup of SOLR integration
 #

--- a/scripts/mercury_install.sh
+++ b/scripts/mercury_install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # mercury_install.sh - Automate the process of installing Pantheon/Mercury
 #

--- a/scripts/migrateSurveyData.sh
+++ b/scripts/migrateSurveyData.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # v37.sh
 #

--- a/scripts/padAddrInfo.sh
+++ b/scripts/padAddrInfo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # padAddrInfo.sh - Left-pad ZIP+4, School District, and County with zeroes
 #

--- a/scripts/readConfig.sh
+++ b/scripts/readConfig.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # readConfig.sh - Read the Bluebird config file and return values
 #

--- a/scripts/rebuildCachedValues.sh
+++ b/scripts/rebuildCachedValues.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # rebuildCachedValues.sh - Rebuild certain CiviCRM cached values.
 #

--- a/scripts/removeCopyright.sh
+++ b/scripts/removeCopyright.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # removeCopyright.sh - Remove any Copyright statement from e-mail footers
 #

--- a/scripts/renameInstance.sh
+++ b/scripts/renameInstance.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # renameInstance.sh - Rename a CRM database instance.
 #

--- a/scripts/reportWebSignups.sh
+++ b/scripts/reportWebSignups.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # reportWebSignups.sh - Generate reports (typically scheduled weekly) for
 #                       nysenate.gov web signups and send to Senators.

--- a/scripts/resetRolePerms.sh
+++ b/scripts/resetRolePerms.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # resetRolePerms.sh - Reset all roles and permissions for a CRM instance
 #

--- a/scripts/rsync_bluebird.sh
+++ b/scripts/rsync_bluebird.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # rsync_bluebird.sh - Synchronize the local repo with the production codebase
 #

--- a/scripts/sageSetup.sh
+++ b/scripts/sageSetup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # sageSetup.sh - The nyss_sage setup script
 #

--- a/scripts/setErrorPage.sh
+++ b/scripts/setErrorPage.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # setErrorPage.sh
 #

--- a/scripts/setOnHold.sh
+++ b/scripts/setOnHold.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # setOnHold.sh - Given a file of undeliverable e-mail addresses, set the
 #                on_hold field for all matching e-mails in the CRM.

--- a/scripts/setOptOuts.sh
+++ b/scripts/setOptOuts.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # setOptOuts.sh - Given a file of opted out e-mail addresses, set the
 #                 is_opt_out field for matching contacts.

--- a/scripts/setPreferences.sh
+++ b/scripts/setPreferences.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # setPreferences.sh - Set CiviCRM preferences for the administrative user.
 #

--- a/scripts/setupCiviMail.sh
+++ b/scripts/setupCiviMail.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # setupCiviMail.sh
 #

--- a/scripts/shadowTable.sh
+++ b/scripts/shadowTable.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # shadowTable.sh
 #


### PR DESCRIPTION
Overview
----------

When running some of the scripts on Ubuntu, I ran into strange failures -- where conditionals evaluated incorrectly. I didn't record the exact error -- but I believe it involved the `==` operator. Switching to `bash` fixed it.

This patch ensures more consistent behavior across different Linux environments.explicit.

Before
-------

The `scripts` point to `/bin/sh`. However, the meaning of `/bin/sh` varies, so some environments are prone to failure.

After
------

Be explicit -- if the scripts are developed with bash, then flag the file as `bash`.

Comments
-------------

`/bin/sh` has been around as long as Unix, but its interpretation varies. Two common interpretations:

* __GNU Bourne Again Shell (bash)__: In the Linux world, there is a strong history of treating `/bin/sh` as an alias for `bash` (and many current distros still do). `bash` has a lot of features. My *guess* is that Bluebird scripts have been developed with bash.
* __Debian Almquist Shell (dash)__: However, `bash` is not universal. In modern versions of Debian (and many Debian-based distros like Ubuntu), they treat `/bin/sh` as an alias for Debian `dash`. The transition to `dash` gives a slightly faster system (*it can save some #milliseconds for sysadmins*), but it also breaks compatibility.

(*Debian allows you to change the shell; and maybe it preserves old preferences for upgraded systems; but the modern default is `dash`, which matters for setting up new development environments.*)

Review of this patch should hinge on the question: _What shell is actually used in Bluebird deployments?_ (You can probably answer with `ls -l /bin/sh`.)

* If the servers are using `sh` => `bash`, then this patch simply reflects the reality, and it will make the scripts more reliable.
* If the servers are using `sh` => `dash`, then the reality is surprising, and we should talk more.
