### PR TITLE
Add configuration option `db.port`

### DIFF
--- a/civicrm/scripts/bluebird_config.php
+++ b/civicrm/scripts/bluebird_config.php
@@ -166,7 +166,11 @@ function get_bluebird_instance_config($instance = null, $filename = null)
   $base_domain = isset($s_bbcfg['base.domain']) ? $s_bbcfg['base.domain'] : $default_base_domain;
   $data_dirname = isset($s_bbcfg['data.dirname']) ? $s_bbcfg['data.dirname'] : $shortname;
 
-  $db_url = 'mysql://'.$s_bbcfg['db.user'].':'.$s_bbcfg['db.pass'].'@'.$s_bbcfg['db.host'].'/';
+  $db_url = 'mysql://'.$s_bbcfg['db.user'].':'.$s_bbcfg['db.pass'].'@'.$s_bbcfg['db.host'];
+  if (!empty($s_bbcfg['db.port'])) {
+    $db_url .= ':'.$s_bbcfg['db.port'];
+  }
+  $db_url .= '/';
   $db_basename = isset($s_bbcfg['db.basename']) ? $s_bbcfg['db.basename'] : $shortname;
   $civicrm_db_name = $s_bbcfg['db.civicrm.prefix'].$db_basename;
   $drupal_db_name = $s_bbcfg['db.drupal.prefix'].$db_basename;

--- a/drupal/sites/default/settings.php
+++ b/drupal/sites/default/settings.php
@@ -47,7 +47,7 @@ $databases = array (
       'username' => $bbconfig['db.user'],
       'password' => $bbconfig['db.pass'],
       'host'     => $bbconfig['db.host'],
-      'port'     => '',
+      'port'     => $bbconfig['db.port'] ?? '',
       'prefix'   => '',
     ),
   ),

--- a/scripts/common_funcs.php
+++ b/scripts/common_funcs.php
@@ -62,14 +62,18 @@ function connect_to_database($bbcfg, $dbtype, $driver = DRIVER_MYSQL)
   }
 
   if ($driver == DRIVER_MYSQL) {
-    $dsn = "mysql:host=${bbcfg['db.host']};dbname=$dbname";
+    $dsn = "mysql:host={$bbcfg['db.host']};dbname=$dbname";
   }
   else if ($driver == DRIVER_PGSQL) {
-    $dsn = "pgsql:host=${bbcfg['db.host']};dbname=$dbname";
+    $dsn = "pgsql:host={$bbcfg['db.host']};dbname=$dbname";
   }
   else {
     echo "Invalid database driver specified\n";
     return null;
+  }
+
+  if (!empty($bbcfg['db.port'])) {
+    $dsn .= ';port=' . $bbcfg['db.port'];
   }
 
   try {

--- a/templates/bluebird.cfg
+++ b/templates/bluebird.cfg
@@ -41,6 +41,7 @@ db.login_path = bluebird
 db.host = DBSERVER
 db.user = DBUSER
 db.pass = DBPASS
+; db.port = DBPORT
 ; set this parameter to 1 to force execSql.sh to use the insecure CLI options
 db.insecure_cli_login = 0
 ; database names are a concatenation of the prefix and the instance name


### PR DESCRIPTION
Overview
-----------

When connecting a PHP application to a MySQL server, you specify credentials (such as hostname, username, and password). This adds an option to specify the MySQL port.

Comments
------------

The style of the patch is fairly guarded -- if your `bluebird.cfg` doesn't specify a database port, then it will behave the same way as before. (It omits the port#, and PHP will make a default guess.)