### PR TITLE
`Mail.php` vs `mail.php` - Prevent conflict on case-insensitive filesystems

### DIFF
--- a/civicrm/custom/php/CRM/Mailing/BAO/MailingJob.php
+++ b/civicrm/custom/php/CRM/Mailing/BAO/MailingJob.php
@@ -19,8 +19,6 @@ use Civi\FlexMailer\FlexMailer;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-require_once 'Mail.php';
-
 /**
  * Class CRM_Mailing_BAO_MailingJob
  */

--- a/modules/civicrm/CRM/Core/Config.php
+++ b/modules/civicrm/CRM/Core/Config.php
@@ -20,7 +20,7 @@
  */
 
 require_once 'Log.php';
-require_once 'Mail.php';
+require_once 'PEAR.php';
 
 require_once 'api/api.php';
 

--- a/modules/civicrm/CRM/Mailing/BAO/MailingJob.php
+++ b/modules/civicrm/CRM/Mailing/BAO/MailingJob.php
@@ -19,8 +19,6 @@ use Civi\FlexMailer\FlexMailer;
  * @copyright CiviCRM LLC https://civicrm.org/licensing
  */
 
-require_once 'Mail.php';
-
 /**
  * Class CRM_Mailing_BAO_MailingJob
  */


### PR DESCRIPTION
If you deploy Bluebird on a workstation with a case-insensitive filesystem, then there is a subtle conflict in the interpretation of this line:

```php
require_once 'Mail.php';
```

which leads to an error:

```
Create data directory: local/import
Updating the CiviCRM/Drupal configuration.
Updating CiviCRM settings
Updating Drupal file_public_path
Drush command terminated abnormally due to an unrecoverable error.                                                                                                                                    [error]
Error: Cannot redeclare mail_civicrm_config() (previously declared in /Users/totten/bknix/build/bluebird/civicrm/custom/ext/gov.nysenate.mail/mail.php:21) in
/Users/totten/bknix/build/bluebird/civicrm/custom/ext/gov.nysenate.mail/Mail.php, line 21
```

The simplest solution is to remove the statement -- in modern CiviCRM, the statement is unnecessary.

This PR is a partial backport of https://github.com/civicrm/civicrm-core/pull/34618. (For longer description, see that issue.)
