### PR TITLE
civicrm.settings.php - If applicable, CIVICRM_UF_BASEURL should include HTTP port

### DIFF
--- a/drupal/sites/default/civicrm.settings.php
+++ b/drupal/sites/default/civicrm.settings.php
@@ -33,6 +33,7 @@ $shortname = get_config_value($bbcfg, 'shortname', null);
 $approot = get_config_value($bbcfg, 'app.rootdir', null);
 $drupalroot = get_config_value($bbcfg, 'drupal.rootdir', null);
 $dataroot = get_config_value($bbcfg, 'data.rootdir', null);
+$httpPort = get_config_value($bbcfg, 'http.port', null);
 
 if (!$servername || !$shortname || !$approot || !$drupalroot || !$dataroot) {
   die("Incorrect config; check these settings: servername, shortname, app.rootdir, drupal.rootdir, data.rootdir\n");
@@ -55,7 +56,12 @@ define('CIVICRM_UF_DSN', $bbcfg['drupal_db_url'].'?new_link=true');
 define('CIVICRM_LOGGING_DSN', $bbcfg['log_db_url'].'?new_link=true');
 
 define('CIVICRM_TEMPLATE_COMPILEDIR', "$dataroot/$datadirname/civicrm/templates_c");
-define('CIVICRM_UF_BASEURL', "http://$servername/");
+define('CIVICRM_UF_BASEURL', implode('', [
+  'http://',
+  $servername,
+  empty($httpPort) ? '' : (':' . $httpPort),
+  '/',
+]));
 define('CIVICRM_SITE_KEY', get_config_value($bbcfg, 'site.key', '32425kj24h5kjh24542kjh524'));
 
 define('CIVICRM_DOMAIN_ID', 1);

--- a/templates/bluebird.cfg
+++ b/templates/bluebird.cfg
@@ -48,6 +48,9 @@ db.civicrm.prefix = senate_c_
 db.drupal.prefix = senate_d_
 db.log.prefix = senate_l_
 
+; global HTTP server settings
+; http.port = 8000
+
 ; global path settings
 app.rootdir = /opt/bluebird
 data.rootdir = /var/bluebird


### PR DESCRIPTION
Overview
--------

Developer workstations often run with HTTP on an alternate port (such as :8000 or :8080).

If this is set, then `CIVICRM_UF_BASEURL` should include the port as part of the URL.

Before
------

On relevant configurations, CIVICRM_UF_BASEURL is always computed incorrectly, leading to broken links.

After
-----

In `bluebird.cfg`, you can set the option `http.port`:

- If set, then `CIVICRM_UF_BASEURL` will be computed correctly.
- If not set, then `CIVICRM_UF_BASEURL` still looks the same as before.