### PR TITLE
civicrm.settings.php - Fix resolution of `civicrm.root` URL

### DIFF
--- a/drupal/sites/default/civicrm.settings.php
+++ b/drupal/sites/default/civicrm.settings.php
@@ -21,6 +21,7 @@ require_once dirname(__FILE__).'/../../../civicrm/scripts/bluebird_config.php';
 // Both of these globals must be here.
 global $civicrm_setting;
 global $civicrm_root;
+global $civicrm_paths;
 
 $bbcfg = get_bluebird_instance_config();
 
@@ -75,6 +76,8 @@ define('SAGE_API_BASE', get_config_value($bbcfg, 'sage.api.base', 'NO_API'));
 //reference value separator explicitly as class constant not yet available
 define('SEP', "");
 
+// There are various symlinks in the build, so path/URL-detection doesn't always work. Be explicit.
+$civicrm_paths['civicrm.root']['url'] = CIVICRM_UF_BASEURL . 'sites/all/modules/civicrm';
 
 //temporary debugging statements
 //CRM_Core_Error::debug_var('bbcfg', $bbcfg);


### PR DESCRIPTION
Overview
----------

Fix an issue with computing URLs for CiviCRM files on new installations.

Before
-------

When opening any page on a new installation, I get several errors about loading JS/CSS resources. The generated HTML looks like this:

```html
<script 
  type="text/javascript" 
  src="http://bluebird.local.civi.bid:8001//Users/totten/bknix/build/bluebird/drupal/sites/all/modules/civicrm/bower_components/jquery/dist/jquery.min.js"
  ></script>
```

Observe that the URL includes `/Users/totten/bknix` (which is part of my local macOS path, but it shouldn't be in the URL).

After
-----

It loads resources with proper URLs:

```html
<script
  type="text/javascript"
  src="http://bluebird.local.civi.bid:8001/sites/all/modules/civicrm/bower_components/jquery/dist/jquery.min.js?t8xezo"
  ></script>
```

Comments
-----------

The short description is that this fixes a major problem for me on new installations. But the careful reader will recognize -- this problem doesn't affect existing sites. Why not?

A couple important bits of context:

* CiviCRM is deployed in many server environments (Drupal; WordPress; Joomla; Standalone; etc), and it needs logic to adapt the URLs for these varied contexts. This logic can get complex. It's tuned to work with common file-layouts, but it can't *automatically* handle  all possible customizations.
* `Bluebird-CRM.git` has a file-layout with multiple symlinks. Symlinks give a tool to customize the file-layout, but they also make it harder to predict the URLs. (Many paths go the same resource, but only one is appropriate to the URL.)
* If you customize the file-layout (as Bluebird does), then CiviCRM often needs some hints about the file-layout.

These hints can be stored in different places:

* In CiviCRM 2.x-3.x, you had to store the hints in the database (e.g. `civicrm_domain` table).
* During CiviCRM 4.x, the options moved to a different table (`civicrm_setting`), and we also gained the ability to set them programmatically in `civicrm.settings.php` (via `$civicrm_setting` and `$civicrm_paths`).
* In CiviCRM 5.x-6.x, I would encourage using `civicrm.settings.php`. If you transfer the databases between different environments (e.g. production/staging/local), then this tends to adapt better.

My guess is that the live sites have hints stored in their databases (e.g. `userFrameworkBaseURL` or `userFrameworkResourceURL`). These database options *should* take precedence over `$civicrm_paths`, so I'd expect them to continue working the same. But if one is creating new instances, this patch should do a better job of fixing at the root (as a single fix).
