### PR TITLE
Create Backup - Use Symfony Process helper

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.backup/CRM/Backup/BAO.php
+++ b/civicrm/custom/ext/gov.nysenate.backup/CRM/Backup/BAO.php
@@ -125,13 +125,17 @@ class CRM_Backup_BAO {
     $approot = $config['bbcfg']['app.rootdir'];
     $instance = $config['bbcfg']['shortname'];
 
-    /*Civi::log()->debug(__FUNCTION__, [
-      'fullFilePath' => $fullFilePath,
-      'approot' => $approot,
-      'instance' => $instance,
-    ]);*/
-
-    shell_exec("$approot/scripts/dumpInstance.sh $instance --zip --archive-file $fullFilePath");
+    $cmd = sprintf("%s/scripts/dumpInstance.sh %s --zip --archive-file %s",
+      escapeshellarg($approot), escapeshellarg($instance), escapeshellarg($fullFilePath));
+    $p = \Symfony\Component\Process\Process::fromShellCommandline($cmd);
+    $exitCode = $p->run();
+    // Civi::log()->debug("Create backup", [
+    //   'cwd' => getcwd(),
+    //   'cmd' => $cmd,
+    //   'exitCode' => $exitCode,
+    //   'output' => $p->getOutput(),
+    //   'error' => $p->getErrorOutput(),
+    // ]);
 
     if (file_exists($fullFilePath)) {
       return TRUE;


### PR DESCRIPTION
This includes a a few overlapping improvements in the same spot:

1. Harden the escaping rules for inputs on subcommands.
2. Switch from `shell_exec()` to Symfony `Process`. When there's a problem, when we can inspec the resulting STDOUT and STDERR data.
3. Update the example log statement -- if you use the log option, you should dump the actual output so that it's easier to find the cause of a problem.

(*Aside: This was in my 3.10 dev branch from a couple months ago. IIRC, it helped me do some debugging for the backup script. When re-sync'ing to current 3.10 dev, I noticed there was no PR for this.*)