### PR TITLE
Update aliased Exception classes to use canonical name

### DIFF
--- a/civicrm/custom/ext/biz.lcdservices.joblogmanagement/api/v3/JobLog/Purge.php
+++ b/civicrm/custom/ext/biz.lcdservices.joblogmanagement/api/v3/JobLog/Purge.php
@@ -29,7 +29,7 @@ function _civicrm_api3_job_log_Purge_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_log_Purge($params) {
   if (CRM_Utils_Array::value('days_retained', $params)) {
@@ -52,7 +52,7 @@ function civicrm_api3_job_log_Purge($params) {
           'api_action' => $apiAction,
         ));
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $error = $e->getMessage();
         CRM_Core_Error::debug_log_message($error);
       }
@@ -76,7 +76,7 @@ function civicrm_api3_job_log_Purge($params) {
 
     return civicrm_api3_create_success(1, $params, 'JobLog', 'Purge');
   } else {
-    throw new API_Exception('Could not purge job logs');
+    throw new CRM_Core_Exception('Could not purge job logs');
   }
 }
 

--- a/civicrm/custom/ext/biz.lcdservices.mosaicoimageeditor/CRM/Mosaicoimageeditor/Page/StoreFrie.php
+++ b/civicrm/custom/ext/biz.lcdservices.mosaicoimageeditor/CRM/Mosaicoimageeditor/Page/StoreFrie.php
@@ -16,7 +16,7 @@ class CRM_Mosaicoimageeditor_Page_StoreFrie extends CRM_Core_Page {
         'url' => $url,
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
     //Civi::log()->debug(__FUNCTION__, ['$result' => $result]);
 
     CRM_Utils_JSON::output(CRM_Utils_Array::value('values', $result));

--- a/civicrm/custom/ext/biz.lcdservices.mosaicoimageeditor/api/v3/Nyss/Storefrie.php
+++ b/civicrm/custom/ext/biz.lcdservices.mosaicoimageeditor/api/v3/Nyss/Storefrie.php
@@ -35,7 +35,7 @@ function _civicrm_api3_nyss_Storefrie_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_Storefrie($params) {
   $image = $params['image'];
@@ -47,7 +47,7 @@ function civicrm_api3_nyss_Storefrie($params) {
     return civicrm_api3_create_success($newUrl, $params, 'Nyss', 'storefrie');
   }
   else {
-    throw new API_Exception('Could not store image.');
+    throw new CRM_Core_Exception('Could not store image.');
   }
 }
 

--- a/civicrm/custom/ext/gov.nysenate.activity/activity.php
+++ b/civicrm/custom/ext/gov.nysenate.activity/activity.php
@@ -138,7 +138,7 @@ function activity_civicrm_postProcess($formName, &$form) {
             'record_type_id' => $targetID,
           ]);
         }
-        catch (CiviCRM_API3_Exception $e) {}
+        catch (CRM_Core_Exception $e) {}
       }
     }
   }

--- a/civicrm/custom/ext/gov.nysenate.boe/boe.php
+++ b/civicrm/custom/ext/gov.nysenate.boe/boe.php
@@ -213,7 +213,7 @@ function boe_civicrm_buildForm($formName, &$form) {
               "address_{$blockId}_street_unit" => CRM_Utils_Array::value('street_unit', $addrVals),
             ]);
           }
-          catch (CiviCRM_API3_Exception $e) {}
+          catch (CRM_Core_Exception $e) {}
         }
 
         foreach ($form->_elementIndex as $ele => $dontcare) {

--- a/civicrm/custom/ext/gov.nysenate.case/CRM/NYSS/Case/Form/CreateCase.php
+++ b/civicrm/custom/ext/gov.nysenate.case/CRM/NYSS/Case/Form/CreateCase.php
@@ -60,7 +60,7 @@ class CRM_NYSS_Case_Form_CreateCase extends CRM_Core_Form {
         'subject' => $values['subject'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
 
     parent::postProcess();
   }

--- a/civicrm/custom/ext/gov.nysenate.contact/CRM/NYSS/Contact/Upgrader.php
+++ b/civicrm/custom/ext/gov.nysenate.contact/CRM/NYSS/Contact/Upgrader.php
@@ -79,7 +79,7 @@ class CRM_NYSS_Contact_Upgrader extends CRM_Extension_Upgrader_Base {
         'column_name' => "preferred_pronouns",
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug(__METHOD__, ['e' => $e]);
     }
 
@@ -102,7 +102,7 @@ class CRM_NYSS_Contact_Upgrader extends CRM_Extension_Upgrader_Base {
         'field_type' => "Individual",
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug(__METHOD__, ['e' => $e]);
     }
 
@@ -125,7 +125,7 @@ class CRM_NYSS_Contact_Upgrader extends CRM_Extension_Upgrader_Base {
         'is_active' => 0,
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug(__METHOD__, ['e' => $e]);
     }
 
@@ -158,7 +158,7 @@ class CRM_NYSS_Contact_Upgrader extends CRM_Extension_Upgrader_Base {
         ->addValue('is_active', TRUE)
         ->execute();
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug(__METHOD__, ['e' => $e]);
     }
 

--- a/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Cleanaddresses.php
+++ b/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Cleanaddresses.php
@@ -22,7 +22,7 @@ function _civicrm_api3_nyss_cleanaddresses_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_cleanaddresses($params) {
   $result = [
@@ -52,7 +52,7 @@ function civicrm_api3_nyss_cleanaddresses($params) {
 
       $result['processed'][] = $dao->id;
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       $result['errored'][] = $dao->id;
     }
   }

--- a/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Cleandates.php
+++ b/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Cleandates.php
@@ -24,7 +24,7 @@ function _civicrm_api3_nyss_cleandates_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_cleandates($params) {
   $result = [

--- a/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Deletetrashed.php
+++ b/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Deletetrashed.php
@@ -29,7 +29,7 @@ function _civicrm_api3_nyss_deletetrashed_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_deletetrashed($params) {
   $params['return'] = TRUE;

--- a/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Purgeusers.php
+++ b/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Purgeusers.php
@@ -48,7 +48,7 @@ function _civicrm_api3_nyss_purgeusers_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_purgeusers($params) {
   $users = _nyss_getUsers($params);

--- a/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Tagmigratedretained.php
+++ b/civicrm/custom/ext/gov.nysenate.contact/api/v3/Nyss/Tagmigratedretained.php
@@ -33,7 +33,7 @@ function _civicrm_api3_nyss_tagmigratedretained_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_tagmigratedretained($params) {
   $results = $tables = [];

--- a/civicrm/custom/ext/gov.nysenate.contact/contact.php
+++ b/civicrm/custom/ext/gov.nysenate.contact/contact.php
@@ -856,7 +856,7 @@ function contact_civicrm_tabset($tabsetName, &$tabs, $context) {
 
       CRM_Core_Error::debug_var('nyss rel', $tabs['n_y_s_s_contact_summary_relationships']);
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
   }
 }
 

--- a/civicrm/custom/ext/gov.nysenate.errorhandler/CRM/NYSS/Errorhandler/BAO.php
+++ b/civicrm/custom/ext/gov.nysenate.errorhandler/CRM/NYSS/Errorhandler/BAO.php
@@ -139,7 +139,7 @@ class CRM_NYSS_Errorhandler_BAO {
           'is_active' => 0,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {}
+      catch (CRM_Core_Exception $e) {}
 
       if (CRM_Utils_Array::value('update_smart_groups', $_REQUEST) == 1) {
         CRM_Core_Session::setStatus(E::ts('ERROR: Group ID %1 could not be loaded and has been disabled.',

--- a/civicrm/custom/ext/gov.nysenate.importcontacts/importcontacts.php
+++ b/civicrm/custom/ext/gov.nysenate.importcontacts/importcontacts.php
@@ -197,7 +197,7 @@ function importcontacts_civicrm_import($object, $usage, &$objectRef, &$params) {
             civicrm_api3('EntityTag', 'create', $entityParams);
           }
         }
-        catch (CiviCRM_API3_Exception $e) {}
+        catch (CRM_Core_Exception $e) {}
       }
     }
   }

--- a/civicrm/custom/ext/gov.nysenate.inbox/CRM/NYSS/Inbox/BAO/Inbox.php
+++ b/civicrm/custom/ext/gov.nysenate.inbox/CRM/NYSS/Inbox/BAO/Inbox.php
@@ -614,7 +614,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
           }
         }
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         Civi::log()->error('assignMessage', ['e' => $e]);
 
         //we arguably should attempt to process all contacts before we
@@ -742,7 +742,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
               'target_contact_id' => $values['assignee'],
             ]);
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             Civi::log()
               ->debug('processMessages update activity target', ['e' => $e]);
             $msg[] = 'Unable to update activity target.';
@@ -765,7 +765,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
                 'entity_table' => 'civicrm_contact',
               ]);
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
               //Civi::log()->debug('processMessages contact keywords', array('e' => $e));
               //$msg[] = 'Unable to assign all keywords to the contact.';
             }
@@ -784,7 +784,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
                 'entity_table' => 'civicrm_contact',
               ]);
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
               //Civi::log()->debug('processMessages contact issue codes', array('e' => $e));
               //$msg[] = 'Unable to assign all issue codes to the contact.';
             }
@@ -825,7 +825,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
             'group_id' => $values['group_id'],
           ]);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           //Civi::log()->debug('processMessages groups', array('e' => $e));
         }
       }
@@ -841,7 +841,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
                 'entity_table' => 'civicrm_activity',
               ]);
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
               //Civi::log()->debug('processMessages activity keywords', array('e' => $e));
               //$msg[] = 'Unable to assign all keywords to the activity.';
             }
@@ -858,7 +858,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
                 'entity_table' => 'civicrm_activity',
               ]);
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
               //Civi::log()->debug('processMessages contact issue codes', array('e' => $e));
               //$msg[] = 'Unable to assign all issue codes to the activity.';
             }
@@ -963,7 +963,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
                 }
               }
             }
-            catch (CiviCRM_API3_Exception $e) {
+            catch (CRM_Core_Exception $e) {
             }
           }
         }
@@ -1053,7 +1053,7 @@ class CRM_NYSS_Inbox_BAO_Inbox {
         $matchedContacts[] = "<a href='{$matchedUrl}'>{$contact['display_name']}</a>";
       }
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
     }
 
     return $matchedContacts;

--- a/civicrm/custom/ext/gov.nysenate.inbox/CRM/NYSS/Inbox/Form/AssignContact.php
+++ b/civicrm/custom/ext/gov.nysenate.inbox/CRM/NYSS/Inbox/Form/AssignContact.php
@@ -109,7 +109,7 @@ class CRM_NYSS_Inbox_Form_AssignContact extends CRM_Core_Form {
               }
             }
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
           }
         }
       }

--- a/civicrm/custom/ext/gov.nysenate.inbox/api/v3/Nyss/Oauthsetup.php
+++ b/civicrm/custom/ext/gov.nysenate.inbox/api/v3/Nyss/Oauthsetup.php
@@ -18,7 +18,7 @@ function _civicrm_api3_nyss_oauthsetup_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_oauthsetup($params) {
   //install oauth-client extension

--- a/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/MosaicoTemplatePrint.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/MosaicoTemplatePrint.php
@@ -16,7 +16,7 @@ class CRM_NYSS_Mail_Page_MosaicoTemplatePrint extends CRM_Core_Page {
       CRM_Utils_System::setTitle($template['title']);
       $this->assign('templateHtml', $template['html']);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       CRM_Core_Error::statusBounce('Unable to retrieve template.', CRM_Utils_System::url('civicrm/mosaico-template-list'));
     }
 

--- a/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/PreviewMailing.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/PreviewMailing.php
@@ -13,7 +13,7 @@ class CRM_NYSS_Mail_Page_PreviewMailing extends CRM_Core_Page {
       $mailing = civicrm_api3('Mailing', 'preview', ['id' => $mailingId]);
       //Civi::log()->debug(__FUNCTION__, ['$mailing' => $mailing]);
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
 
     $this->assign('content', $mailing['values']['body_html']);
 

--- a/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/PreviewRecipients.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/PreviewRecipients.php
@@ -39,7 +39,7 @@ class CRM_NYSS_Mail_Page_PreviewRecipients extends CRM_Core_Page {
       ]);
       //Civi::log()->debug(__FUNCTION__, ['$count' => $count]);
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
 
     $partialCount = 50;
     if ($recipients['count'] < 50) {

--- a/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/RecipientReview.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Page/RecipientReview.php
@@ -41,13 +41,13 @@ class CRM_NYSS_Mail_Page_RecipientReview extends CRM_Core_Page {
               'email' => $email,
             ];
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             Civi::log()->debug(__FUNCTION__, ['$e' => $e]);
           }
 
         }
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         Civi::log()->debug(__FUNCTION__, ['$e' => $e]);
       }
     }

--- a/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Upgrader.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Mail/Upgrader.php
@@ -70,7 +70,7 @@ class CRM_NYSS_Mail_Upgrader extends CRM_Extension_Upgrader_Base {
         civicrm_api3('OptionValue', 'delete', ['id' => $opt['id']]);
       }
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
 
     $cats = [
       [
@@ -124,7 +124,7 @@ class CRM_NYSS_Mail_Upgrader extends CRM_Extension_Upgrader_Base {
           'icon' => NULL,
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {}
+      catch (CRM_Core_Exception $e) {}
     }
 
     return TRUE;

--- a/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Subscription/Form/Manage.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/CRM/NYSS/Subscription/Form/Manage.php
@@ -243,6 +243,6 @@ class CRM_NYSS_Subscription_Form_Manage extends CRM_Core_Form {
         2 => [date('YmdHis'), 'Timestamp'],
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
   }
 }//end class

--- a/civicrm/custom/ext/gov.nysenate.mail/api/v3/Nyss/Generatemailtemplate.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/api/v3/Nyss/Generatemailtemplate.php
@@ -31,7 +31,7 @@ function _civicrm_api3_nyss_Generatemailtemplate_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_Generatemailtemplate($params) {
   $response = ['result' => ''];

--- a/civicrm/custom/ext/gov.nysenate.mail/api/v3/Nyss/Processmosaicothumbnails.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/api/v3/Nyss/Processmosaicothumbnails.php
@@ -18,7 +18,7 @@ function _civicrm_api3_nyss_Processmosaicothumbnails_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_Processmosaicothumbnails($params) {
   //Civi::log()->debug(__FUNCTION__, ['params' => $params]);
@@ -26,7 +26,7 @@ function civicrm_api3_nyss_Processmosaicothumbnails($params) {
   try {
     $results = CRM_NYSS_Mail_Utils::createMosaicoThumbnails();
   }
-  catch (CiviCRM_API3_Exception $e) {}
+  catch (CRM_Core_Exception $e) {}
 
   return civicrm_api3_create_success($results, $params, 'Nyss', 'Processmosaicothumbnails');
 }

--- a/civicrm/custom/ext/gov.nysenate.mail/api/v3/Nyss/Purgedraftemails.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/api/v3/Nyss/Purgedraftemails.php
@@ -30,7 +30,7 @@ function _civicrm_api3_nyss_Purgedraftemails_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_Purgedraftemails($params) {
   //Civi::log()->debug(__FUNCTION__, ['params' => $params]);
@@ -53,7 +53,7 @@ function civicrm_api3_nyss_Purgedraftemails($params) {
       }
     }
   }
-  catch (CiviCRM_API3_Exception $e) {}
+  catch (CRM_Core_Exception $e) {}
 
   return civicrm_api3_create_success(['count' => count($mailingIds), 'ids' => $mailingIds], $params, 'Nyss', 'Purgedraftemails');
 }

--- a/civicrm/custom/ext/gov.nysenate.mail/mail.php
+++ b/civicrm/custom/ext/gov.nysenate.mail/mail.php
@@ -895,7 +895,7 @@ function mail_civicrm_buildForm($formName, &$form) {
         'mailing_id' => $form->_mailingID,
       ]);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug(__FUNCTION__, ['$e' => $e]);
     }
 
@@ -1009,7 +1009,7 @@ function mail_civicrm_alterMailParams(&$params, $context) {
         try {
           $eventQueue = civicrm_api3('MailingEventQueue', 'getsingle', ['id' => $params['event_queue_id']]);
           $params[NyssFlexmailListener::$PARAM_CONTACT_ID] = CRM_Utils_Array::value('contact_id', $eventQueue);
-        } catch (CiviCRM_API3_Exception $e) {
+        } catch (CRM_Core_Exception $e) {
           Civi::log()->debug(__FUNCTION__, ['e' => $e]);
         }
       }

--- a/civicrm/custom/ext/gov.nysenate.merge/merge.php
+++ b/civicrm/custom/ext/gov.nysenate.merge/merge.php
@@ -495,7 +495,7 @@ function _merge_fixRT(&$data, &$rows, &$conflicts) {
         $conflicts['move_custom_61'] = array_search($rtMain, $recordTypeOpts['values'], 2);
       }
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
   }
 } //_merge_fixRT()
 
@@ -549,7 +549,7 @@ function _merge_fixPrivacyNote($mainId, $otherId) {
       return "{$pnA}; {$pnB}";
     }
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     _merge_mD('error retrieving privacy note: $e', $e);
   }
 

--- a/civicrm/custom/ext/gov.nysenate.tags/CRM/Tags/NYSS.php
+++ b/civicrm/custom/ext/gov.nysenate.tags/CRM/Tags/NYSS.php
@@ -19,7 +19,7 @@ class CRM_Tags_NYSS {
             'value' => $tag,
           ));
         }
-        catch (CiviCRM_API3_Exception $e) {}
+        catch (CRM_Core_Exception $e) {}
       }
       else {
         $tags[] = $tag;

--- a/civicrm/custom/ext/gov.nysenate.tags/api/v3/Tag/SavePosition.php
+++ b/civicrm/custom/ext/gov.nysenate.tags/api/v3/Tag/SavePosition.php
@@ -44,7 +44,7 @@ function civicrm_api3_tag_save_position($params) {
 
       return $tag['id'];
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->error('civicrm_api3_nyss_tags_savePosition', array('e' => $e));
     }
   } else {

--- a/civicrm/custom/ext/gov.nysenate.tags/tags.php
+++ b/civicrm/custom/ext/gov.nysenate.tags/tags.php
@@ -84,7 +84,7 @@ function tags_civicrm_buildForm($formName, &$form) {
           ]);
         //Civi::log()->debug('buildForm', array('$setName' => $setName));
       }
-      catch (CiviCRM_API3_Exception $e) {}
+      catch (CRM_Core_Exception $e) {}
 
       if (in_array($setName, $webSets)) {
         $webViewOnly[] = $setDetails['parentID'];
@@ -352,7 +352,7 @@ function tags_civicrm_postProcess($formName, &$form) {
               }
             }
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             Civi::log()->debug('CRM_Contact_Form_Task_AddToTag', ['$e' => $e]);
           }
         }

--- a/civicrm/custom/ext/gov.nysenate.testing/api/v3/NyssTest/Integrationnotify.php
+++ b/civicrm/custom/ext/gov.nysenate.testing/api/v3/NyssTest/Integrationnotify.php
@@ -18,7 +18,7 @@ function _civicrm_api3_nyss_test_Integrationnotify_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_test_Integrationnotify($params) {
   $db = 'test.db';

--- a/civicrm/custom/ext/gov.nysenate.testing/api/v3/NyssTest/Mailpaused.php
+++ b/civicrm/custom/ext/gov.nysenate.testing/api/v3/NyssTest/Mailpaused.php
@@ -18,7 +18,7 @@ function _civicrm_api3_nyss_test_Mailpaused_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_nyss_test_Mailpaused($params) {
   CRM_NYSS_BAO_Mailing::notify(11159);

--- a/civicrm/custom/ext/gov.nysenate.webintegration/CRM/NYSS/WebIntegration/Upgrader.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/CRM/NYSS/WebIntegration/Upgrader.php
@@ -44,7 +44,7 @@ class CRM_NYSS_WebIntegration_Upgrader extends CRM_Extension_Upgrader_Base {
         ));
       }
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug('install', array('$e' => $e));
     }
   }

--- a/civicrm/custom/ext/gov.nysenate.webintegration/api/v3/WebIntegration/Migratemsgs.php
+++ b/civicrm/custom/ext/gov.nysenate.webintegration/api/v3/WebIntegration/Migratemsgs.php
@@ -45,7 +45,7 @@ function _civicrm_api3_web_integration_migratemsgs_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_web_integration_migratemsgs($params) {
   global $_MigrateMsgsDebug;
@@ -89,7 +89,7 @@ function civicrm_api3_web_integration_migratemsgs($params) {
       break;
 
     default:
-      throw new API_Exception('Invalid Action');
+      throw new CRM_Core_Exception('Invalid Action');
   }
 
   return civicrm_api3_create_success(['processed' => $result], $params, 'WebIntegration', 'MigrateMsgs');
@@ -147,7 +147,7 @@ function _wimm_Migrate($limit, $type) {
 
       $i ++;
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug('_wimm_Migrate', [
         '$e' => $e,
         '$dao' => $dao,
@@ -193,7 +193,7 @@ function _wimm_Purge($limit, $type) {
 
       $i ++;
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->debug('_wimm_Migrate', [
         '$e' => $e,
         '$dao' => $dao,

--- a/civicrm/custom/php/CRM/Activity/Page/AJAX.php
+++ b/civicrm/custom/php/CRM/Activity/Page/AJAX.php
@@ -78,7 +78,7 @@ class CRM_Activity_Page_AJAX {
           'return' => 'current_employer',
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $relationship['organization'] = '';
       }
 

--- a/civicrm/custom/php/CRM/NYSS/BAO/Integration/Website.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Integration/Website.php
@@ -532,7 +532,7 @@ class CRM_NYSS_BAO_Integration_Website
         ]);
         //CRM_Core_Error::debug_var('$tag', $tag);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         CRM_Core_Error::debug_var('processPetition tag creation', $e);
         return [
           'is_error' => 1,
@@ -554,7 +554,7 @@ class CRM_NYSS_BAO_Integration_Website
     try {
       $et = self::entityTagAction($contactId, $tagId, $apiAction);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       CRM_Core_Error::debug_var('CRM_NYSS_BAO_Integration_Website::processPetition $e', $e);
     }
 
@@ -634,7 +634,7 @@ class CRM_NYSS_BAO_Integration_Website
       $result = civicrm_api3('custom_value', 'create', $profileParams);
       //CRM_Core_Error::debug_var('update profile result', $result);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       // handle error here
       $errorMessage = $e->getMessage();
       $errorCode = $e->getErrorCode();
@@ -757,7 +757,7 @@ class CRM_NYSS_BAO_Integration_Website
       $result = civicrm_api3('activity', 'create', $params);
       //CRM_Core_Error::debug_var('processCommunication result', $result);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       // handle error here
       $errorMessage = $e->getMessage();
       $errorCode = $e->getErrorCode();
@@ -845,7 +845,7 @@ class CRM_NYSS_BAO_Integration_Website
         return $cf;
       }
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       CRM_Core_Error::debug_var('Survey Construction Issue', $e, TRUE, TRUE, 'integration');
     }
 
@@ -1008,7 +1008,7 @@ class CRM_NYSS_BAO_Integration_Website
         $cg = civicrm_api3('custom_group', 'create', $params);
         $csID = $cg['id'];
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         CRM_Core_Error::debug_var('buildSurvey $e', $e, TRUE, TRUE, 'integration');
 
         return FALSE;
@@ -1074,7 +1074,7 @@ class CRM_NYSS_BAO_Integration_Website
         $existingFieldNames[] = $field_name;
         $fieldCreated = TRUE;
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $fieldCreated = FALSE;
         CRM_Core_Error::debug_var('buildSurvey $e', $e, TRUE, TRUE, 'integration');
       }
@@ -1642,7 +1642,7 @@ class CRM_NYSS_BAO_Integration_Website
         $results = civicrm_api3('entity_tag', $action, $params);
       }
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       CRM_Core_Error::debug_var('CRM_NYSS_BAO_Integration_Website::entityTagAction', $e);
     }
 

--- a/civicrm/custom/php/CRM/NYSS/BAO/Mailing.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/Mailing.php
@@ -86,7 +86,7 @@ class CRM_NYSS_BAO_Mailing {
 
       return $job['id'];
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
 
     return NULL;
   }

--- a/civicrm/custom/php/CRM/NYSS/BAO/NYSS.php
+++ b/civicrm/custom/php/CRM/NYSS/BAO/NYSS.php
@@ -211,7 +211,7 @@ class CRM_NYSS_BAO_NYSS {
         $result['values'][$idx]['data'] = "{$contact['sort_name']} [Case #{$case['id']} :: {$case['subject']}]";
       }
     }
-    catch (CiviCRM_API3_Exception $e) {}
+    catch (CRM_Core_Exception $e) {}
 
     //Civi::log()->debug(__FUNCTION__, ['$result' => $result]);
     return $result;

--- a/civicrm/custom/php/api/v3/NyssTags.php
+++ b/civicrm/custom/php/api/v3/NyssTags.php
@@ -108,7 +108,7 @@ function civicrm_api3_nyss_tags_savePosition($params) {
 
       return $tag['id'];
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->error('civicrm_api3_nyss_tags_savePosition', array('e' => $e));
     }
   }


### PR DESCRIPTION
`CiviCRM_API3_Exception` and `API_Exception` are merely aliases of `CRM_Core_Exception`, so this is NFC.

https://github.com/nysenate/Bluebird-CRM/blob/eeb339d0ea8dc803370f6d978d7b2f453c54404f/modules/civicrm/api/Exception.php#L13-L20