### PR TITLE
Remove obsolete activity hook code

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.activity/activity.php
+++ b/civicrm/custom/ext/gov.nysenate.activity/activity.php
@@ -113,37 +113,6 @@ function _activity_buildForm_unfreeze_activity_type(&$form) {
     }
 }
 
-function activity_civicrm_postProcess($formName, &$form) {
-  /*Civi::log()->debug('activity_civicrm_postProcess', array(
-    'formName' => $formName,
-    'form' => $form,
-  ));*/
-
-  if (in_array($formName, array('CRM_Contact_Form_Task_Email')) &&
-    $form->_action == CRM_Core_Action::ADD &&
-    !empty($form->_activityId)
-  ) {
-    if (!empty($form->_ccContactIds) || !empty($form->_bccContactIds)) {
-      $ccBccIds = array_merge($form->_ccContactIds, $form->_bccContactIds);
-      //Civi::log()->debug('activity_civicrm_postProcess', array('$ccBccIds' => $ccBccIds));
-
-      $activityContacts = CRM_Core_OptionGroup::values('activity_contacts', FALSE, FALSE, FALSE, NULL, 'name');
-      $targetID = CRM_Utils_Array::key('Activity Targets', $activityContacts);
-
-      foreach ($ccBccIds as $cid) {
-        try {
-          civicrm_api3('activity_contact', 'create', [
-            'activity_id' => $form->_activityId,
-            'contact_id' => $cid,
-            'record_type_id' => $targetID,
-          ]);
-        }
-        catch (CRM_Core_Exception $e) {}
-      }
-    }
-  }
-}
-
 function activity_civicrm_alterMailParams(&$params, $context) {
   /*Civi::log()->debug(__FUNCTION__, [
     'params' => $params,


### PR DESCRIPTION
Issue https://dev.nysenate.gov/issues/18904

The function `activity_civicrm_postProcess()` found in extension gov.nysenate.activity is non-functional.

* The legacy form properties `$form->_ccContactIds`, `$form->_bccContactIds`, and `$form->_activityId` are never populated on $form.
* As a result, the condition `!empty($form->_activityId)` and `!empty($form->_ccContactIds)` always evaluates to FALSE, so the code inside the hook never runs.

If no one has noticed this breakage, then the function is probably not needed. It appears to have been previously used to add cc and bcc contacts to the activity as contacts, but CiviCRM automatically records CC and BCC contacts in the details field of the email activity (e.g. `cc : <a href="...">Contact Name</a>` and `bcc : <a href="...">Contact Name</a>`) during `CRM_Contact_Form_Task_EmailTrait::submit()`.