### PR TITLE
Remove obsolete optionValues hook code

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.activity/activity.php
+++ b/civicrm/custom/ext/gov.nysenate.activity/activity.php
@@ -174,11 +174,3 @@ function activity_civicrm_alterMailParams(&$params, $context) {
     $params['from'] = $fromEmail;
   }
 }
-
-#[CRM_NYSS_Attribute_IssueRef(4921)]
-function activity_civicrm_optionValues(&$options, $groupName) {
-    // NYSS 4921 - alphabetize activity types
-    if ($groupName == 'activity_type') {
-        asort($options);
-    }
-}


### PR DESCRIPTION
Fixes https://dev.nysenate.gov/issues/18978

`hook_civicrm_optionValues` is deprecated and doesn't work in most contexts. This hook probably wasn't working and is probably not needed.

It was previously used to alphabetize activity type options, but those dropdowns now use Select2 which is searchable, so they are easier to find even if not alphabetized.