### PR TITLE
Migrate tokens to use modern TokenProcessor

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.tokens/Civi/Tokens/TokensSubscriber.php
+++ b/civicrm/custom/ext/gov.nysenate.tokens/Civi/Tokens/TokensSubscriber.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\Tokens;
+
+use Civi\Core\Service\AutoSubscriber;
+use Civi\Token\Event\TokenRegisterEvent;
+use Civi\Token\Event\TokenValueEvent;
+use CRM_Tokens_ExtensionUtil as E;
+
+/**
+ * Token subscriber for NYSS custom tokens.
+ *
+ * @service tokens.subscriber
+ */
+class TokensSubscriber extends AutoSubscriber {
+
+  public static function getSubscribedEvents(): array {
+    return [
+      'civi.token.list' => 'registerTokens',
+      'civi.token.eval' => 'evaluateTokens',
+    ];
+  }
+
+  /**
+   * Register custom NYSS tokens.
+   *
+   * @param \Civi\Token\Event\TokenRegisterEvent $e
+   */
+  public function registerTokens(TokenRegisterEvent $e): void {
+    $e->entity('nyss')
+      ->register('base_url', E::ts('Base URL'))
+      ->register('senator_formal', E::ts('Senator Formal Name'))
+      ->register('senator_email', E::ts('Senator Email'));
+  }
+
+  /**
+   * Evaluate custom NYSS tokens.
+   *
+   * @param \Civi\Token\Event\TokenValueEvent $e
+   */
+  public function evaluateTokens(TokenValueEvent $e): void {
+    $activeTokens = $e->getTokenProcessor()->getMessageTokens();
+    if (empty($activeTokens['nyss'])) {
+      return;
+    }
+
+    $bbconfig = function_exists('get_bluebird_instance_config') ? get_bluebird_instance_config() : [];
+    $basename = $bbconfig['db.basename'] ?? '';
+    $domain = $bbconfig['base.domain'] ?? '';
+    $bb = [
+      'base_url' => ($basename && $domain) ? "{$basename}.{$domain}" : '',
+      'senator_formal' => $bbconfig['senator.name.formal'] ?? '',
+      'senator_email' => $bbconfig['senator.email'] ?? '',
+    ];
+
+    foreach ($e->getRows() as $row) {
+      $row->format('text/html');
+      foreach ($activeTokens['nyss'] as $token) {
+        if ($token === 'base_url') {
+          $row->tokens('nyss', 'base_url', 'http://' . $bb['base_url']);
+        }
+        elseif ($token === 'senator_formal') {
+          $row->tokens('nyss', 'senator_formal', $bb['senator_formal']);
+        }
+        elseif ($token === 'senator_email') {
+          $row->tokens('nyss', 'senator_email', $bb['senator_email']);
+        }
+      }
+    }
+  }
+
+}

--- a/civicrm/custom/ext/gov.nysenate.tokens/phpunit.xml.dist
+++ b/civicrm/custom/ext/gov.nysenate.tokens/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" stopOnFailure="false" cacheResult="false" bootstrap="tests/phpunit/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./</directory>
+    </include>
+  </coverage>
+  <listeners>
+    <listener class="Civi\Test\CiviTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
+  <testsuites>
+    <testsuite name="gov.nysenate.tokens Tests">
+      <directory>./tests/phpunit</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/civicrm/custom/ext/gov.nysenate.tokens/tests/phpunit/Civi/Tokens/TokensTest.php
+++ b/civicrm/custom/ext/gov.nysenate.tokens/tests/phpunit/Civi/Tokens/TokensTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types = 1);
+namespace Civi\Tokens;
+
+use Civi\Token\TokenProcessor;
+
+/**
+ * Tests for gov.nysenate.tokens.
+ */
+class TokensTest extends \PHPUnit\Framework\TestCase {
+
+  public function setUp(): void {
+    parent::setUp();
+    require_once dirname(__DIR__, 4) . '/tokens.civix.php';
+  }
+
+  /**
+   * Test that TokensSubscriber declares subscriptions to the required token events.
+   */
+  public function testSubscribedEvents(): void {
+    $events = TokensSubscriber::getSubscribedEvents();
+    $this->assertArrayHasKey('civi.token.list', $events);
+    $this->assertArrayHasKey('civi.token.eval', $events);
+    $this->assertSame('registerTokens', $events['civi.token.list']);
+    $this->assertSame('evaluateTokens', $events['civi.token.eval']);
+  }
+
+  /**
+   * Test that the 3 custom tokens are registered on the nyss entity:
+   * - {nyss.base_url}
+   * - {nyss.senator_formal}
+   * - {nyss.senator_email}
+   */
+  public function testTokensRegistration(): void {
+    $subscriber = new TokensSubscriber();
+    $dispatcher = new \Civi\Core\CiviEventDispatcher(new \Symfony\Component\EventDispatcher\EventDispatcher());
+    $dispatcher->addListener('civi.token.list', [$subscriber, 'registerTokens']);
+
+    $tp = new TokenProcessor($dispatcher, ['controller' => __CLASS__]);
+    $tokens = $tp->listTokens();
+
+    $this->assertArrayHasKey('{nyss.base_url}', $tokens, 'Expected token "{nyss.base_url}" to be registered');
+    $this->assertArrayHasKey('{nyss.senator_formal}', $tokens, 'Expected token "{nyss.senator_formal}" to be registered');
+    $this->assertArrayHasKey('{nyss.senator_email}', $tokens, 'Expected token "{nyss.senator_email}" to be registered');
+
+    $this->assertSame('Base URL', $tokens['{nyss.base_url}']);
+    $this->assertSame('Senator Formal Name', $tokens['{nyss.senator_formal}']);
+    $this->assertSame('Senator Email', $tokens['{nyss.senator_email}']);
+  }
+
+  /**
+   * Test that tokens are evaluated and rendered correctly by TokensSubscriber.
+   */
+  public function testTokensEvaluation(): void {
+    $subscriber = new TokensSubscriber();
+    $dispatcher = new \Civi\Core\CiviEventDispatcher(new \Symfony\Component\EventDispatcher\EventDispatcher());
+    $dispatcher->addListener('civi.token.eval', [$subscriber, 'evaluateTokens']);
+
+    $tp = new TokenProcessor($dispatcher, ['controller' => __CLASS__]);
+    $tp->addMessage('test_msg', 'URL: {nyss.base_url}, Name: {nyss.senator_formal}, Email: {nyss.senator_email}', 'text/plain');
+    $tp->addRow(['contactId' => 1]);
+    $tp->evaluate();
+
+    foreach ($tp->getRows() as $row) {
+      $rendered = $row->render('test_msg');
+      $this->assertStringContainsString('URL:', $rendered);
+      $this->assertStringContainsString('Name:', $rendered);
+      $this->assertStringContainsString('Email:', $rendered);
+    }
+  }
+
+}

--- a/civicrm/custom/ext/gov.nysenate.tokens/tests/phpunit/bootstrap.php
+++ b/civicrm/custom/ext/gov.nysenate.tokens/tests/phpunit/bootstrap.php
@@ -1,0 +1,69 @@
+<?php
+
+ini_set('memory_limit', '2G');
+
+$_SERVER['HTTP_HOST'] = 'bluebird';
+putenv('INSTANCE_NAME=bluebird');
+$_ENV['INSTANCE_NAME'] = 'bluebird';
+
+// phpcs:disable
+eval(cv('php:boot --level=classloader', 'phpcode'));
+// phpcs:enable
+// Allow autoloading of PHPUnit helper classes in this extension.
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+
+$loader->register();
+
+/**
+ * Call the "cv" command.
+ *
+ * @param string $cmd
+ *   The rest of the command to send.
+ * @param string $decode
+ *   Ex: 'json' or 'phpcode'.
+ * @return mixed
+ *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
+ * @throws \RuntimeException
+ *   If the command terminates abnormally.
+ */
+function cv(string $cmd, string $decode = 'json') {
+  $cmd = 'cv ' . $cmd;
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
+  $oldOutput = getenv('CV_OUTPUT');
+  putenv('CV_OUTPUT=json');
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
+  $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
+  putenv("CV_OUTPUT=$oldOutput");
+  fclose($pipes[0]);
+  $result = stream_get_contents($pipes[1]);
+  fclose($pipes[1]);
+  if (proc_close($process) !== 0) {
+    throw new RuntimeException("Command failed ($cmd):\n$result");
+  }
+  switch ($decode) {
+    case 'raw':
+      return $result;
+
+    case 'phpcode':
+      // If the last output is /*PHPCODE*/, then we managed to complete execution.
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
+        throw new \RuntimeException("Command failed ($cmd):\n$result");
+      }
+      return $result;
+
+    case 'json':
+      return json_decode($result, 1);
+
+    default:
+      throw new RuntimeException("Bad decoder format ($decode)");
+  }
+}

--- a/civicrm/custom/ext/gov.nysenate.tokens/tokens.php
+++ b/civicrm/custom/ext/gov.nysenate.tokens/tokens.php
@@ -29,36 +29,3 @@ function tokens_civicrm_install() {
 function tokens_civicrm_enable() {
   _tokens_civix_civicrm_enable();
 }
-
-function tokens_civicrm_tokens(&$tokens) {
-  $tokens['nyss'] = [
-    'nyss.base_url' => 'Base URL',
-    'nyss.senator_formal' => 'Senator Formal Name',
-    'nyss.senator_email' => 'Senator Email',
-  ];
-}
-
-function tokens_civicrm_tokenValues(&$values, $cids, $job, $tokens, $context) {
-  /*Civi::log()->debug(__FUNCTION__, [
-    'values' => $values,
-    'cids' => $cids,
-    'tokens' => $tokens,
-  ]);*/
-
-  if (!empty($tokens['nyss'])) {
-    $bbconfig = get_bluebird_instance_config();
-    $bb = [
-      'base_url' => "{$bbconfig['db.basename']}.{$bbconfig['base.domain']}",
-      'senator_formal' => CRM_Utils_Array::value('senator.name.formal', $bbconfig),
-      'senator_email' => CRM_Utils_Array::value('senator.email', $bbconfig),
-    ];
-
-    foreach ($cids as $cid) {
-      $values[$cid] = [
-        'nyss.base_url' => 'http://'.$bb['base_url'],
-        'nyss.senator_formal' => $bb['senator_formal'],
-        'nyss.senator_email' => $bb['senator_email'],
-      ];
-    }
-  }
-}


### PR DESCRIPTION
Ticket: https://dev.nysenate.gov/issues/18979

Migrated gov.nysenate.tokens from the deprecated legacy hooks (hook_civicrm_tokens and hook_civicrm_tokenValues) to CiviCRM's modern TokenProcessor event system using an AutoSubscriber service, and added a PHPUnit test suite.