### PR TITLE
Remove redundant fields_callbacks for user_unique_id and county_id

### DIFF
--- a/civicrm/custom/ext/gov.nysenate.dao/dao.php
+++ b/civicrm/custom/ext/gov.nysenate.dao/dao.php
@@ -34,7 +34,6 @@ function dao_civicrm_entityTypes(&$entityTypes) {
     $fields['do_not_trade']['title'] = 'Undeliverable: Do Not Mail';//4766
 
     //set fields that should not be exportable
-    $fields['user_unique_id']['export'] = FALSE;//2719
     $fields['contact_sub_type']['export'] = FALSE;
     //$fields['current_employer_id']['export'] = FALSE; //13123 this breaks things downstream with API calls
     $fields['hash']['export'] = FALSE;
@@ -74,7 +73,6 @@ function dao_civicrm_entityTypes(&$entityTypes) {
     $fields['geo_code_2']['export'] = FALSE;
     $fields['name']['export'] = FALSE;
     $fields['master_id']['export'] = FALSE;
-    $fields['county_id']['export'] = FALSE;
   };
 
   $entityTypes['WorldRegion']['fields_callback'][] = function($class, &$fields) {


### PR DESCRIPTION
Issue: https://dev.nysenate.gov/issues/17442

### Overview
Removes two redundant field callback modifications in `gov.nysenate.dao`:
* **Contact.user_unique_id** (`export = FALSE`): In CiviCRM core schema (`Contact.entityType.php`), `user_unique_id` is a deprecated field and has `'usage' => []`, so it is already not exportable.
* **Address.county_id** (`export = FALSE`): In CiviCRM core schema (`Address.entityType.php`), `county_id` defines `'usage' => ['import', 'duplicate_matching']`, which already omits `'export'` by default.